### PR TITLE
Fix broken link to PPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ On a sufficiently recent Ubuntu, these are all available via `apt-get`:
 
     sudo apt-get install libgflags-dev libjson0-dev libboost-system-dev libboost-filesystem-dev
 
-I have also made packages available in a [PPA](lg-ppa), but they are
+I have also made packages available in a [PPA][lg-ppa], but they are
 largely unmaintained since I no longer deploy livegrep on any older
 distributions.
 


### PR DESCRIPTION
Thought I'd pass this along, since I didn't look for the PPA at all after the link, and ended up building gflags and libgit from source elsewhere. The PPA was much better. :smile: Thanks!

Might be worth mentioning that I also had to `go get` `github.com/golang/glog`, `github.com/bmizerany/pat`, and `code.google.com/p/go.net/websocket` for the web interface to work after a clean golang 1.2.1 install. (the error messages were fairly verbose and lucid though). Not sure if this has something to do with the go version, or just more dependencies.
