### PR TITLE
Re-ordering path matching, to prefer path with backend specified.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -145,14 +145,14 @@ func New(cfg *config.Config) (http.Handler, error) {
 
 	m := pat.New()
 	m.Add("GET", "/", srv.Handler(srv.ServeRoot))
-	m.Add("GET", "/search/", srv.Handler(srv.ServeSearch))
 	m.Add("GET", "/search/:backend", srv.Handler(srv.ServeSearch))
+	m.Add("GET", "/search/", srv.Handler(srv.ServeSearch))
 	m.Add("GET", "/about", srv.Handler(srv.ServeAbout))
 	m.Add("GET", "/debug/healthcheck", srv.Handler(srv.ServeHealthcheck))
 	m.Add("GET", "/opensearch.xml", srv.Handler(srv.ServeOpensearch))
 
-	m.Add("GET", "/api/v1/search/", srv.Handler(srv.ServeAPISearch))
 	m.Add("GET", "/api/v1/search/:backend", srv.Handler(srv.ServeAPISearch))
+	m.Add("GET", "/api/v1/search/", srv.Handler(srv.ServeAPISearch))
 
 	mux := http.NewServeMux()
 	mux.Handle("/assets/", http.FileServer(http.Dir(path.Join(cfg.DocRoot, "htdocs"))))


### PR DESCRIPTION
The backend that I was choosing wasn't being respected.
After confirming (with bin/dump_file) that the backend
should have had the right data (and killing the relevant
backend and not seeing any change) and adding some logging,
I realized that the :backend parameter wasn't being
passed along into api.go.

Based on my reading of pat/mux.go, specifically:

```
  if ph.pat != "/" && len(ph.pat) > 0 && ph.pat[len(ph.pat)-1] == '/' {
          return p, true
```

It seems that any pattern that ends with a slash can match
even if there's random stuff after it.  And, yes, the Add()
calls are ordered.

I've tested the /api call manually.  The /search path seems
to have the same issue, so I changed that too.
