### PR TITLE
Correctly render OpenSearch template

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -142,7 +142,7 @@ func (s *server) ServeOpensearch(ctx context.Context, w http.ResponseWriter, r *
 		}
 	}
 
-	body, err := executeTextTemplate(s.T.OpenSearch, data)
+	body, err := executeTemplate(s.T.OpenSearch, data)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	texttemplate "text/template"
 	"time"
 
 	"code.google.com/p/go.net/context"
@@ -24,7 +25,7 @@ type Templates struct {
 	Index,
 	About,
 	Help *template.Template
-	OpenSearch *template.Template `template:"opensearch.xml"`
+	OpenSearch *texttemplate.Template `template:"opensearch.xml"`
 }
 
 type server struct {
@@ -141,11 +142,13 @@ func (s *server) ServeOpensearch(ctx context.Context, w http.ResponseWriter, r *
 		}
 	}
 
-	body, err := executeTemplate(s.T.OpenSearch, data)
+	body, err := executeTextTemplate(s.T.OpenSearch, data)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
 		return
 	}
+
+	w.Header().Set("Content-Type", "application/xml")
 	w.Write(body)
 }
 

--- a/server/templates.go
+++ b/server/templates.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"html/template"
+	texttemplate "text/template"
 
 	"github.com/livegrep/livegrep/server/config"
 )
@@ -14,6 +15,14 @@ type page struct {
 	Title  string
 	Body   template.HTML
 	Config *config.Config
+}
+
+func executeTextTemplate(t *texttemplate.Template, context interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, context); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func executeTemplate(t *template.Template, context interface{}) ([]byte, error) {

--- a/server/templates.go
+++ b/server/templates.go
@@ -6,7 +6,6 @@ import (
 	"log"
 
 	"html/template"
-	texttemplate "text/template"
 
 	"github.com/livegrep/livegrep/server/config"
 )
@@ -17,15 +16,11 @@ type page struct {
 	Config *config.Config
 }
 
-func executeTextTemplate(t *texttemplate.Template, context interface{}) ([]byte, error) {
-	var buf bytes.Buffer
-	if err := t.Execute(&buf, context); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+type Template interface {
+  Execute(wr io.Writer, data interface{}) error
 }
 
-func executeTemplate(t *template.Template, context interface{}) ([]byte, error) {
+func executeTemplate(t Template, context interface{}) ([]byte, error) {
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, context); err != nil {
 		return nil, err

--- a/server/templates/templates.go
+++ b/server/templates/templates.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"reflect"
 	"strings"
+	texttemplate "text/template"
 )
 
 func templatePath(f reflect.StructField) string {
@@ -29,12 +30,21 @@ func Load(base string, templates interface{}) error {
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 
-		if !f.Type.AssignableTo(reflect.TypeOf((*template.Template)(nil))) {
+		is_html_template := f.Type.AssignableTo(reflect.TypeOf((*template.Template)(nil)))
+		is_text_template := f.Type.AssignableTo(reflect.TypeOf((*texttemplate.Template)(nil)))
+		if !is_html_template && !is_text_template {
 			continue
 		}
 
 		p := templatePath(f)
-		tpl, err := template.ParseFiles(path.Join(base, p))
+		var err error
+		var tpl interface{}
+		if is_html_template {
+			tpl, err = template.ParseFiles(path.Join(base, p))
+		} else {
+			tpl, err = texttemplate.ParseFiles(path.Join(base, p))
+		}
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
r? @nelhage 

XML doesn't render properly under html/template, resulting in the `&lt;` at http://livegrep.com/opensearch.xml

Not the cleanest solution, but without pulling in https://github.com/tcard/go-template-interface or similar I don't think we can do much better.

That said, this is my first time writing Go, so :dogscience: