### PR TITLE
Simplified callback declaration and added an optional transform function

### DIFF
--- a/src/codesearch.cc
+++ b/src/codesearch.cc
@@ -886,9 +886,9 @@ code_searcher::search_thread::search_thread(code_searcher *cs)
     }
 }
 
-void code_searcher::search_thread::match_internal(const query &q,
-                                                  const code_searcher::search_thread::base_cb& cb,
-                                                  match_stats *stats) {
+void code_searcher::search_thread::match(const query &q,
+                                         const callback_func& cb,
+                                         match_stats *stats) {
     match_result *m;
     int matches = 0;
 


### PR DESCRIPTION
(1) Use boost::function to simplify the callback function declaration
(2) Allow a filter/transform function to be specified. I have a prototype to look at an index of tags files and then transform the tags match to the actual code match. I can remove this second part if you'd prefer, since it may stay unused if my ctags prototype doesn't make it.