### PR TITLE
Added support for searching through ctags results

### DIFF
--- a/client/types.go
+++ b/client/types.go
@@ -4,10 +4,12 @@ type Query struct {
 	Line     string `json:"line"`
 	File     string `json:"file"`
 	Repo     string `json:"repo"`
+	Tags     string `json:"tags"`
 	FoldCase bool   `json:"fold_case"`
 	Not      struct {
 		File string `json:"file"`
 		Repo string `json:"repo"`
+		Tags string `json:"tags"`
 	} `json:"not"`
 }
 

--- a/server/query.go
+++ b/server/query.go
@@ -80,8 +80,10 @@ func ParseQuery(query string) client.Query {
 	var out client.Query
 	out.File = ops["file"]
 	out.Repo = ops["repo"]
+	out.Tags = ops["tags"]
 	out.Not.File = ops["-file"]
 	out.Not.Repo = ops["-repo"]
+	out.Not.Tags = ops["-tags"]
 	out.Line = strings.TrimSpace(ops[""] + ops["case"] + regexp.QuoteMeta(ops["lit"]))
 	if _, ok := ops["case"]; ok {
 		out.FoldCase = false

--- a/server/query_test.go
+++ b/server/query_test.go
@@ -8,14 +8,16 @@ import (
 )
 
 func TestParseQuery(t *testing.T) {
-	Not := func(file, repo string) struct {
+	Not := func(file, repo, tags string) struct {
 		File string `json:"file"`
 		Repo string `json:"repo"`
+		Tags string `json:"tags"`
 	} {
 		return struct {
 			File string `json:"file"`
 			Repo string `json:"repo"`
-		}{file, repo}
+			Tags string `json:"tags"`
+		}{file, repo, tags}
 	}
 	cases := []struct {
 		in  string
@@ -90,12 +92,20 @@ func TestParseQuery(t *testing.T) {
 			client.Query{Line: "(file:)", FoldCase: true},
 		},
 		{
+			`re tags:kind:function`,
+			client.Query{Line: "re", FoldCase: true, Tags: "kind:function"},
+		},
+		{
 			`-file:Godep re`,
-			client.Query{Line: "re", Not: Not("Godep", ""), FoldCase: true},
+			client.Query{Line: "re", Not: Not("Godep", "", ""), FoldCase: true},
 		},
 		{
 			`-file:. -repo:Godep re`,
-			client.Query{Line: "re", Not: Not(".", "Godep"), FoldCase: true},
+			client.Query{Line: "re", Not: Not(".", "Godep", ""), FoldCase: true},
+		},
+		{
+			`-tags:kind:class re`,
+			client.Query{Line: "re", Not: Not("", "", "kind:class"), FoldCase: true},
 		},
 		{
 			`case:foo:`,

--- a/src/Makefrag
+++ b/src/Makefrag
@@ -1,3 +1,4 @@
 SRC += src/chunk_allocator.cc src/chunk.cc src/codesearch.cc \
            src/content.cc src/dump_load.cc src/indexer.cc \
-           src/re_width.cc src/git_indexer.cc src/fs_indexer.cc
+           src/re_width.cc src/git_indexer.cc src/fs_indexer.cc \
+           src/tagsearch.cc

--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -15,8 +15,8 @@
 #include <atomic>
 #include <mutex>
 #include <thread>
+#include <functional>
 #include <boost/intrusive_ptr.hpp>
-#include <boost/function.hpp>
 
 #ifdef USE_DENSE_HASH_SET
 #include <google/dense_hash_set>
@@ -127,7 +127,7 @@ struct match_result {
 };
 
 // A query specification passed to match(). line_pat is required to be
-// non-NULL; file_pat and tree_pat may be NULL to specify "no
+// non-NULL; file_pat, tree_pat and tag_pat may be NULL to specify "no
 // constraint"
 struct query {
     std::string trace_id;
@@ -135,9 +135,11 @@ struct query {
     std::unique_ptr<RE2> line_pat;
     std::unique_ptr<RE2> file_pat;
     std::unique_ptr<RE2> tree_pat;
+    std::unique_ptr<RE2> tags_pat;
     struct {
         std::unique_ptr<RE2> file_pat;
         std::unique_ptr<RE2> tree_pat;
+        std::unique_ptr<RE2> tags_pat;
     } negate;
 };
 
@@ -178,9 +180,9 @@ public:
         ~search_thread();
 
         // function that will be called to record a match
-        typedef boost::function<void (const struct match_result*)> callback_func;
+        typedef std::function<void (const struct match_result*)> callback_func;
         // function that will be called to transform a match
-        typedef boost::function<bool (struct match_result*)> transform_func;
+        typedef std::function<bool (struct match_result*)> transform_func;
 
         /* file_pat may be NULL */
         void match(const query& q, const callback_func& cb, match_stats *stats)
@@ -189,7 +191,8 @@ public:
         }
         void match(const query& q,
                    const callback_func& cb,
-                   const transform_func& func, match_stats *stats);
+                   const transform_func& func,
+                   match_stats *stats);
     protected:
         struct job {
             atomic_int pending;
@@ -219,6 +222,7 @@ protected:
     friend class searcher;
     friend class codesearch_index;
     friend class load_allocator;
+    friend class tag_searcher;
 };
 
 // dump_load.cc

--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -179,9 +179,17 @@ public:
 
         // function that will be called to record a match
         typedef boost::function<void (const struct match_result*)> callback_func;
+        // function that will be called to transform a match
+        typedef boost::function<bool (struct match_result*)> transform_func;
 
         /* file_pat may be NULL */
-        void match(const query& q, const callback_func& cb, match_stats *stats);
+        void match(const query& q, const callback_func& cb, match_stats *stats)
+        {
+            match(q, cb, transform_func(), stats);
+        }
+        void match(const query& q,
+                   const callback_func& cb,
+                   const transform_func& func, match_stats *stats);
     protected:
         struct job {
             atomic_int pending;

--- a/src/tagsearch.cc
+++ b/src/tagsearch.cc
@@ -1,0 +1,118 @@
+/********************************************************************
+ * livegrep -- tagsearch.cc
+ * Copyright (c) 2011-2013 Nelson Elhage
+ *
+ * This program is free software. You may use, redistribute, and/or
+ * modify it under the terms listed in the COPYING file.
+ ********************************************************************/
+#include "tagsearch.h"
+#include "content.h"
+#include "lib/debug.h"
+
+#include <utility>
+
+using re2::RE2;
+
+void tag_searcher::load_index(const string& path) {
+    cs_.load_index(path);
+}
+
+void tag_searcher::cache_indexed_files(code_searcher* cs) {
+    file_alloc_ = cs->alloc_;
+    for (auto it = cs->begin_files(); it != cs->end_files(); ++it) {
+        auto file = *it;
+        auto key = repo_path_pair(file->tree->name, file->path);
+        path_to_file_map_.insert(std::make_pair(key, file));
+    }
+}
+
+std::string tag_searcher::create_tag_line_regex(
+    const std::string& name,
+    const std::string& file,
+    const std::string& lno,
+    const std::string& tags) const
+{
+    // full regex match for a tag line created with ctags using format=2.
+    return std::string("^") + name + "\\t" + file + "\\t" + lno + "\\;\\\"\\t" + tags + "$";
+}
+
+std::string tag_searcher::create_partial_regex(RE2 *re) const {
+    if (!re)
+        return ".*";
+
+    std::string pattern = re->pattern();
+
+    if (pattern.front() == '^')
+        pattern.erase(pattern.begin());
+    else
+        pattern.insert(0, ".*");
+
+    if (pattern.back() == '$')
+        pattern.erase(pattern.size() - 1);
+    else
+        pattern.append(".*");
+
+    return pattern;
+}
+
+bool tag_searcher::transform(query *q, match_result *m) const {
+    static const std::string regex = create_tag_line_regex("(.+)", "(.+)", "(\\d+)", "(.+)");
+    StringPiece name, path, tags;
+    if (!RE2::FullMatch(m->line, regex, &name, &path, &m->lno, &tags)) {
+        log(q->trace_id, "unknown ctags format: %s\n", m->line.as_string().c_str());
+        return false;
+    }
+
+    // check the negation constraints
+    if (q->negate.file_pat &&
+        q->negate.file_pat->Match(path, 0, path.size(), RE2::UNANCHORED, NULL, 0))
+        return false;
+    if (q->negate.tags_pat &&
+        q->negate.tags_pat->Match(tags, 0, tags.size(), RE2::UNANCHORED, NULL, 0))
+        return false;
+
+    // lookup the indexed_file base on repo and path
+    auto key = repo_path_pair(m->file->tree->name, path.as_string());
+    auto value = path_to_file_map_.find(key);
+    if (value == path_to_file_map_.end()) {
+        log(q->trace_id,
+            "unable to find a file matching %s from repo %s\n",
+            path.as_string().c_str(), m->file->tree->name.c_str());
+        return false;
+    }
+    auto file = value->second;
+
+    // iterate through the lines to add context information
+    auto line_it = file->content->begin(file_alloc_);
+    auto line_end = file->content->end(file_alloc_);
+    const int kContextLines = 3;
+    m->file = file;
+
+    // jump to context before
+    int current = 1;
+    for (;current < std::max(1, m->lno - kContextLines); ++current)
+        ++line_it;
+
+    // context before (we reverse the order to match codesearch)
+    m->context_before.clear();
+    for (; current < m->lno; ++current) {
+        m->context_before.insert(m->context_before.begin(), *line_it);
+        ++line_it;
+    }
+
+
+    // line (match the first occurrence for simplicity)
+    m->line = *line_it;
+    m->matchleft = line_it->find(name);
+    m->matchright = m->matchleft + name.size();
+    ++line_it;
+
+    // context after
+    m->context_after.clear();
+    for (int i = 0; i < kContextLines && line_it != line_end; ++i) {
+        m->context_after.push_back(*line_it);
+        ++line_it;
+    }
+
+    return true;
+}

--- a/src/tagsearch.h
+++ b/src/tagsearch.h
@@ -22,17 +22,11 @@ public:
 
     void cache_indexed_files(code_searcher *cs);
 
-    std::string create_partial_regex(RE2 *re) const;
-
-    std::string create_tag_line_regex(
-        const std::string& name,
-        const std::string& file,
-        const std::string& lno,
-        const std::string& tags) const;
-
     bool transform(query *q, match_result *m) const;
 
     code_searcher* cs() { return &cs_; }
+
+    static std::string create_tag_line_regex_from_query(query *q);
 
 protected:
     code_searcher cs_;

--- a/src/tagsearch.h
+++ b/src/tagsearch.h
@@ -1,0 +1,44 @@
+/********************************************************************
+ * livegrep -- tagsearch.h
+ * Copyright (c) 2011-2013 Nelson Elhage
+ *
+ * This program is free software. You may use, redistribute, and/or
+ * modify it under the terms listed in the COPYING file.
+ ********************************************************************/
+#ifndef TAGSEARCH_H
+#define TAGSEARCH_H
+
+#include "codesearch.h"
+
+#include <map>
+#include <string>
+
+class RE2;
+class chunk_allocator;
+
+class tag_searcher {
+public:
+    void load_index(const string& path);
+
+    void cache_indexed_files(code_searcher *cs);
+
+    std::string create_partial_regex(RE2 *re) const;
+
+    std::string create_tag_line_regex(
+        const std::string& name,
+        const std::string& file,
+        const std::string& lno,
+        const std::string& tags) const;
+
+    bool transform(query *q, match_result *m) const;
+
+    code_searcher* cs() { return &cs_; }
+
+protected:
+    code_searcher cs_;
+    chunk_allocator *file_alloc_;
+    typedef std::pair<std::string, std::string> repo_path_pair;
+    std::map<repo_path_pair, indexed_file*> path_to_file_map_;
+};
+
+#endif /* TAGSEARCH_H */

--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -96,11 +96,7 @@ struct tagsearch_matcher {
         constraints.negate.tags_pat.swap(q->negate.tags_pat);
 
         // modify the line pattern to match the constraints that we can handle now
-        std::string name = ts_->create_partial_regex(q->line_pat.get());
-        std::string file = ts_->create_partial_regex(q->file_pat.get());
-        std::string tags = ts_->create_partial_regex(q->tags_pat.get());
-        std::string regex = ts_->create_tag_line_regex(name, file, "\\d+", tags);
-
+        std::string regex = tag_searcher::create_tag_line_regex_from_query(q);
         q->line_pat.reset(new RE2(regex, q->line_pat->options()));
         q->file_pat.reset();
         q->tags_pat.reset();

--- a/src/tools/transport.cc
+++ b/src/tools/transport.cc
@@ -208,11 +208,15 @@ json_parse_error parse_object(json_object *js, query *q) {
         err = parse_regex(b, "file", opts, &q->file_pat);
     if (err.ok())
         err = parse_regex(b, "repo", opts, &q->tree_pat);
+    if (err.ok())
+        err = parse_regex(b, "tags", opts, &q->tags_pat);
 
     if (err.ok() && negate)
         err = parse_regex(negate, "file", opts, &q->negate.file_pat);
     if (err.ok() && negate)
         err = parse_regex(negate, "repo", opts, &q->negate.tree_pat);
+    if (err.ok() && negate)
+        err = parse_regex(negate, "tags", opts, &q->negate.tags_pat);
 
     return err;
 }


### PR DESCRIPTION
This addresses what I wanted in #23. 

To use this, you would:
1. Create a tags file with ctags on your source
2. Run codesearch -dump_index on the tags file
3. Run codesearch -load_index and -load_tags, with the tags backend listening on another port
4. Make sure to modify server.json to refer to both backends

The overall algorithm is pretty simple. I use the tags index for searching through lines in the tags file. For each match in the tags file, I transform the match by using the source index to get the context lines.

There are still some rough spots, such as lack of documentation on setting this up, or the fact that you need to ensure that the tags file would have the same path as the path stored in the index file. However, I find that this is actually quite useful in finding definitions quickly, while still maintaining the speed that livegrep is known for.
