### PR TITLE
Fix `lit:` (regressed in previous commit)

### DIFF
--- a/server/query.go
+++ b/server/query.go
@@ -88,12 +88,17 @@ func ParseQuery(query string) (client.Query, error) {
 	var bits []string
 	for _, k := range []string{"", "case", "lit"} {
 		bit := strings.TrimSpace(ops[k])
+		if k == "lit" {
+			bit = regexp.QuoteMeta(bit)
+		}
 		if len(bit) != 0 {
 			bits = append(bits, bit)
 		}
 	}
 	out.Line = strings.Join(bits, "")
 	if _, ok := ops["case"]; ok {
+		out.FoldCase = false
+	} else if _, ok := ops["lit"]; ok {
 		out.FoldCase = false
 	} else {
 		out.FoldCase = strings.IndexAny(out.Line, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") == -1

--- a/server/query_test.go
+++ b/server/query_test.go
@@ -111,6 +111,10 @@ func TestParseQuery(t *testing.T) {
 			`case:foo:`,
 			client.Query{Line: "foo:", FoldCase: false},
 		},
+		{
+			`lit:.`,
+			client.Query{Line: `\.`, FoldCase: false},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
And add a test.

should fix the regression from #28 