### PR TITLE
Add dep for @boost//:bind to grpc_server

### DIFF
--- a/src/tools/BUILD
+++ b/src/tools/BUILD
@@ -8,6 +8,8 @@ cc_library(
   deps = [
     "//src:codesearch",
     "//src/proto:cc_proto",
+
+    "@boost//:bind",
     "@com_github_grpc_grpc//:grpc",
   ],
   visibility = [ "//visibility:public" ],


### PR DESCRIPTION
Fixes:

```
jacob:shell:master:~/src/third_party/livegrep
$ bazel build //...
INFO: Found 40 targets...
ERROR: /home/jacob/src/third_party/livegrep/src/tools/BUILD:1:1: C++ compilation of rule '//src/tools:grpc_server' failed: linux-sandbox failed: error executing command /home/jacob/.cache/bazel/_bazel_jacob/0e3155d251e04ba4aa26ee3b6c5c65f1/execroot/livegrep/_bin/linux-sandbox ... (remaining 283 argument(s) skipped).
src/tools/grpc_server.cc:17:26: fatal error: boost/bind.hpp: No such file or directory
 #include <boost/bind.hpp>
                          ^
compilation terminated.
INFO: Elapsed time: 17.760s, Critical Path: 17.30s
```