### PR TITLE
Update to a version of re2 which includes a workaround for a bug in gcc 6.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,7 +23,7 @@ new_patched_http_archive(
 git_repository(
   name = "com_googlesource_code_re2",
   remote = "git://github.com/google/re2",
-  commit = "ec8dfdfa39233663779f01935124ecc36e840a03",
+  commit = "b94b7cd42e9f02673cd748c1ac1d16db4052514c",
 )
 
 git_repository(


### PR DESCRIPTION
Due to a regression in gcc 6.1 re2 failed to build at one point. Here's an issue describing the problem: https://github.com/google/re2/issues/102

I've updated the reference to the commit which includes the workaround. I haven't investigated what else changed between the two versions but I can if you'd like. If you'd rather see it use an even newer version of re2 I could also investigate that.

Fixes:

```
jacob:shell:master:~/src/third_party/livegrep
$ bazel build //...
INFO: Found 40 targets...
ERROR: /home/jacob/.cache/bazel/_bazel_jacob/0e3155d251e04ba4aa26ee3b6c5c65f1/external/com_googlesource_code_re2/BUILD:11:1: C++ compilation of rule '@com_googlesource_code_re2//:re2' failed: linux-sandbox failed: error executing command /home/jacob/.cache/bazel/_bazel_jacob/0e3155d251e04ba4aa26ee3b6c5c65f1/execroot/livegrep/_bin/linux-sandbox ... (remaining 40 argument(s) skipped).
external/com_googlesource_code_re2/re2/dfa.cc: In constructor 're2::DFA::State::State()':
external/com_googlesource_code_re2/re2/dfa.cc:109:10: error: unknown array size in delete
   struct State {
          ^~~~~
external/com_googlesource_code_re2/re2/dfa.cc: In member function 're2::DFA::State* re2::DFA::CachedState(int*, int, uint32_t)':
external/com_googlesource_code_re2/re2/dfa.cc:718:9: note: synthesized method 're2::DFA::State::State()' first required here 
   State state;
         ^~~~~
INFO: Elapsed time: 29.224s, Critical Path: 20.61s
```

After this and the other two PRs I opened (#32, #31) it builds on my Yakkety Google Cloud instance :)