### PR TITLE
Update readme to use grpc, as the frontend no longer works with the legacy method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ built both `codesearch` and `livegrep`:
 
 In one terminal, start the `codesearch` server like so:
 
-    bazel-bin/src/tools/codesearch -listen tcp://localhost:9999 doc/examples/livegrep/index.json
+    bazel-bin/src/tools/codesearch -grpc localhost:9999 doc/examples/livegrep/index.json
 
 In another, run livegrep:
 
@@ -66,7 +66,7 @@ future runs. Index files are standalone, and you no longer need access
 to the source code repositories, or even a configuration file, once an
 index has been built. You can just launch a search server like so:
 
-    bazel-bin/src/tools/codesearch -load_index livegrep.idx  -listen tcp://localhost:9999
+    bazel-bin/src/tools/codesearch -load_index livegrep.idx -grpc localhost:9999
 
 ## `livegrep`
 


### PR DESCRIPTION
Perhaps the -listen option and relevant code should be removed from the source in a different commit?