### PR TITLE
Render GitHub links correctly for any GitHub origin

### DIFF
--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -480,7 +480,7 @@ func buildConfig(name string,
 			Name:      *r.FullName,
 			Revisions: []string{revision},
 			Metadata: map[string]string{
-				"github": *r.FullName,
+				"github": *r.HTMLURL,
 			},
 		})
 	}


### PR DESCRIPTION
Tested and live now in Stripe's QA env. 