### PR TITLE
Fix compilation error.

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -258,9 +258,9 @@ namespace {
     intrusive_ptr<IndexKey> CaseFoldLiteral(Rune *runes, int nrunes) {
         if (nrunes == 0)
             return Empty();
-        intrusive_ptr<IndexKey> keys[nrunes];
+        std::vector<intrusive_ptr<IndexKey> > keys;
         for (int i = 0; i < nrunes; ++i) {
-            keys[i] = CaseFoldLiteral(runes[i]);
+            keys.push_back(CaseFoldLiteral(runes[i]));
         }
         return Concat(&keys[0], nrunes);
     }


### PR DESCRIPTION
The variable length array failed to compile on my computer because we
were using an `intrusive_ptr`. Switching to `std::vector` fixed it.

Fixes #42 