### PR TITLE
indexer: check whether ref resolved to commit

### DIFF
--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -43,7 +43,10 @@ git_indexer::~git_indexer() {
 void git_indexer::walk(const string& ref) {
     smart_object<git_commit> commit;
     smart_object<git_tree> tree;
-    git_revparse_single(commit, repo_, (ref + "^0").c_str());
+    if (0 != git_revparse_single(commit, repo_, (ref + "^0").c_str())) {
+        fprintf(stderr, "ref %s not found, skipping (empty repo?)\n", ref.c_str());
+        return;
+    }
     git_commit_tree(tree, commit);
 
     char oidstr[GIT_OID_HEXSZ+1];


### PR DESCRIPTION
This fixes ("works for me") issue #46.

No regression test is included. I started writing a higher level test that would call `build_index()` or `git_indexer`'s `walk()` against `doc/example/index.json` (and other example json files), but got bogged down in not knowing how to bazel.

Thank you for maintaining livegrep!