### PR TITLE
Group multiple search results within a file

### DIFF
--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -55,8 +55,6 @@ body {
 
 #resultbox {
     width: 100%;
-    border: 1px solid black;
-    padding: 5px;
 }
 
 .label {
@@ -67,8 +65,59 @@ body {
     clear: both;
 }
 
+#results {
+    margin-top: 10px;
+}
+
+.file-group {
+    background: rgba(34, 76, 89, 0.05);
+    margin-bottom: 15px;
+    border: solid 1px rgba(0, 0, 0, 0.1);
+    border-left: solid 3px #A0D1FA;
+}
+
+.file-group .header {
+    color: #3d464d;
+    font-family: monospace;
+    font-weight: normal;
+    display: block;
+    background: rgba(0, 126, 229, 0.04);
+    padding: 3px 5px;
+}
+
+.file-group .header .filename {
+    font-weight: bold;
+}
+
+.file-group .header .repo, .file-group .header .version {
+    color: rgba(0, 0, 0, 0.5);
+}
+
 .match {
-    margin: 1em 2em;
+    display: block;
+    border: solid 0 rgba(0, 0, 0, 0.15);
+    border-top-width: 1px;
+    margin-top: 5px;
+    text-decoration: none;
+    background-color: #fff;
+}
+
+.match:first-of-type {
+    border-top-width: 0;
+    margin-top: 0px;
+}
+
+.match.clip-before {
+    margin-top: 0;
+    border-top: none;
+}
+
+.match.clip-before .contents {
+    padding-top: 0;
+}
+
+.match.clip-after .contents {
+    padding-bottom: 0;
 }
 
 .match .label {
@@ -84,7 +133,10 @@ body {
 }
 
 .lno {
-    text-align: center;
+    display: inline-block;
+    width: 3em;
+    margin-right: 1em;
+    text-align: right;
     -moz-user-select: none;
     -webkit-user-select: none;
     -ms-user-select: none;
@@ -105,10 +157,9 @@ tr:nth-child(even) {
 .match .contents {
     white-space: pre-wrap;
     font-family: monospace;
-    background: #eee;
-    border: 1px solid black;
-    margin-left: 1em;
-    margin-top: 5px;
+    padding: 10px 5px;
+    color: #000;
+    margin: 0;
 }
 
 .matchstr{
@@ -123,10 +174,6 @@ tr:nth-child(even) {
 
 .contents div.code {
     padding: 3px 0px;
-}
-
-.match .lno {
-    width: 3em;
 }
 
 .line {

--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -179,6 +179,8 @@ tr:nth-child(even) {
 
 .line {
     word-wrap: break-word;
+    display: grid;
+    grid-template-columns: 4em auto;
 }
 
 .code {

--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -123,16 +123,14 @@ a:hover {
     padding-bottom: 0;
 }
 
-.match .label {
+.match .contents {
+    display: grid;
+    grid-template-columns: 4em auto;
+    white-space: pre-wrap;
     font-family: monospace;
-}
-
-.match .more {
-    font-size: 90%;
-}
-
-.matchline .lno {
-    font-weight: bold;
+    padding: 10px 5px;
+    color: #000;
+    margin: 0;
 }
 
 .lno-link {
@@ -145,43 +143,12 @@ a:hover {
     content: attr(aria-label);
 }
 
-.code {
-    width: 100%;
+.matchlno {
+    font-weight: bold;
 }
 
-tr:nth-child(even) {
-    background: #DDDDDD;
-}
-
-.match .contents {
-    display: grid;
-    grid-template-columns: 4em auto;
-    white-space: pre-wrap;
-    font-family: monospace;
-    padding: 10px 5px;
-    color: #000;
-    margin: 0;
-}
-
-.matchstr{
+.matchstr {
     background: #FFFF00;
-}
-
-.contents div.lnos {
-    float: left;
-    border-right: 1px solid grey;
-    padding: 3px 0px 3px 3px;
-}
-
-.contents div.code {
-    padding: 3px 0px;
-}
-
-.code {
-    table-layout: fixed;
-}
-
-.match .matchstr {
     font-weight: bold;
 }
 

--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -135,15 +135,16 @@ a:hover {
     font-weight: bold;
 }
 
-.lno {
+.lno-link {
     display: inline-block;
     color: #3d464d;
     width: 3em;
     padding-right: 1em;
     text-align: right;
-    -moz-user-select: none;
-    -webkit-user-select: none;
-    -ms-user-select: none;
+}
+
+.lno:before {
+    content: attr(aria-label);
 }
 
 .code {

--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -136,9 +136,7 @@ a:hover {
 }
 
 .lno-link {
-    display: inline-block;
     color: #3d464d;
-    width: 3em;
     padding-right: 1em;
     text-align: right;
 }

--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -3,6 +3,14 @@ body {
     font-family: sans-serif;
 }
 
+a {
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
 #searcharea {
     width: 40em;
     margin: auto;
@@ -21,10 +29,6 @@ body {
 .querybox {
     font-size: 80%;
     text-align: center;
-}
-
-.querybox .help a {
-    text-decoration: none;
 }
 
 #searcharea input {
@@ -98,7 +102,6 @@ body {
     border: solid 0 rgba(0, 0, 0, 0.15);
     border-top-width: 1px;
     margin-top: 5px;
-    text-decoration: none;
     background-color: #fff;
 }
 
@@ -134,16 +137,13 @@ body {
 
 .lno {
     display: inline-block;
+    color: #3d464d;
     width: 3em;
-    margin-right: 1em;
+    padding-right: 1em;
     text-align: right;
     -moz-user-select: none;
     -webkit-user-select: none;
     -ms-user-select: none;
-}
-
-.lno:before {
-    content: attr(line_number);
 }
 
 .code {

--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -154,6 +154,8 @@ tr:nth-child(even) {
 }
 
 .match .contents {
+    display: grid;
+    grid-template-columns: 4em auto;
     white-space: pre-wrap;
     font-family: monospace;
     padding: 10px 5px;
@@ -173,12 +175,6 @@ tr:nth-child(even) {
 
 .contents div.code {
     padding: 3px 0px;
-}
-
-.line {
-    word-wrap: break-word;
-    display: grid;
-    grid-template-columns: 4em auto;
 }
 
 .code {

--- a/web/htdocs/assets/js/codesearch_ui.js
+++ b/web/htdocs/assets/js/codesearch_ui.js
@@ -59,7 +59,9 @@ var MatchView = Backbone.View.extend({
   },
   _renderLno: function(n, isMatch) {
     var lnoStr = n.toString() + (isMatch ? ":" : "-");
-    return h.a({cls: 'lno-link', href: this.model.url(n)}, [
+    var classes = ['lno-link'];
+    if (isMatch) classes.push('matchline');
+    return h.a({cls: classes.join(' '), href: this.model.url(n)}, [
       h.span({cls: 'lno', 'aria-label': lnoStr}, []),
     ]);
   },
@@ -72,17 +74,17 @@ var MatchView = Backbone.View.extend({
 
     var lines_to_display_before = Math.max(0, ctxBefore.length - (clip_before || 0));
     for (i = 0; i < lines_to_display_before; i ++) {
-      ctx_before.unshift(h.div({cls: 'line'}, [
-                                 this._renderLno(lno - i - 1, false),
-                                 h.span([this.model.get('context_before')[i]]),
-                               ]));
+      ctx_before.unshift(
+        this._renderLno(lno - i - 1, false),
+        h.span([this.model.get('context_before')[i]]),
+      );
     }
     var lines_to_display_after = Math.max(0, ctxAfter.length - (clip_after || 0));
     for (i = 0; i < lines_to_display_after; i ++) {
-      ctx_after.push(h.div({cls: 'line'}, [
-                             this._renderLno(lno + i + 1, false),
-                             h.span([this.model.get('context_after')[i]]),
-                           ]));
+      ctx_after.push(
+        this._renderLno(lno + i + 1, false),
+        h.span([this.model.get('context_after')[i]]),
+      );
     }
     var line = this.model.get('line');
     var bounds = this.model.get('bounds');
@@ -95,13 +97,15 @@ var MatchView = Backbone.View.extend({
     if(clip_after !== undefined) classes.push('clip-after');
 
     var matchElement = h.div({cls: classes.join(' ')}, [
-        h.div({cls: 'contents'}, [
-                ctx_before,
-                h.div({cls: 'line matchline'}, [
-                  this._renderLno(lno, true),
-                  h.span([pieces[0], h.span({cls: 'matchstr'}, [pieces[1]]), pieces[2]]),
-                ]),
-                ctx_after])]);
+      h.div({cls: 'contents'}, [].concat(
+        ctx_before,
+        [
+            this._renderLno(lno, true),
+            h.span({cls: 'matchline'}, [pieces[0], h.span({cls: 'matchstr'}, [pieces[1]]), pieces[2]]),
+        ],
+        ctx_after,
+      )),
+    ]);
 
     return matchElement;
   }

--- a/web/htdocs/assets/js/codesearch_ui.js
+++ b/web/htdocs/assets/js/codesearch_ui.js
@@ -62,7 +62,7 @@ var MatchView = Backbone.View.extend({
     var classes = ['lno'];
     if (isMatch) classes.push('matchlno');
     return h.a({cls: 'lno-link', href: this.model.url(n)}, [
-      h.span({cls: classes.join(' '), 'aria-label': lnoStr}, []),
+      h.span({cls: classes.join(' '), 'aria-label': lnoStr}, [])
     ]);
   },
   _render: function() {
@@ -76,14 +76,14 @@ var MatchView = Backbone.View.extend({
     for (i = 0; i < lines_to_display_before; i ++) {
       ctx_before.unshift(
         this._renderLno(lno - i - 1, false),
-        h.span([this.model.get('context_before')[i]]),
+        h.span([this.model.get('context_before')[i]])
       );
     }
     var lines_to_display_after = Math.max(0, ctxAfter.length - (clip_after || 0));
     for (i = 0; i < lines_to_display_after; i ++) {
       ctx_after.push(
         this._renderLno(lno + i + 1, false),
-        h.span([this.model.get('context_after')[i]]),
+        h.span([this.model.get('context_after')[i]])
       );
     }
     var line = this.model.get('line');
@@ -101,10 +101,10 @@ var MatchView = Backbone.View.extend({
         ctx_before,
         [
             this._renderLno(lno, true),
-            h.span({cls: 'matchline'}, [pieces[0], h.span({cls: 'matchstr'}, [pieces[1]]), pieces[2]]),
+            h.span({cls: 'matchline'}, [pieces[0], h.span({cls: 'matchstr'}, [pieces[1]]), pieces[2]])
         ],
-        ctx_after,
-      )),
+        ctx_after
+      ))
     ]);
 
     return matchElement;
@@ -125,7 +125,7 @@ var Match = Backbone.Model.extend({
       id: tree + ':' + version + ':' + path,
       tree: tree,
       version: version,
-      path: path,
+      path: path
     }
   },
 

--- a/web/htdocs/assets/js/codesearch_ui.js
+++ b/web/htdocs/assets/js/codesearch_ui.js
@@ -59,10 +59,10 @@ var MatchView = Backbone.View.extend({
   },
   _renderLno: function(n, isMatch) {
     var lnoStr = n.toString() + (isMatch ? ":" : "-");
-    var classes = ['lno-link'];
-    if (isMatch) classes.push('matchline');
-    return h.a({cls: classes.join(' '), href: this.model.url(n)}, [
-      h.span({cls: 'lno', 'aria-label': lnoStr}, []),
+    var classes = ['lno'];
+    if (isMatch) classes.push('matchlno');
+    return h.a({cls: 'lno-link', href: this.model.url(n)}, [
+      h.span({cls: classes.join(' '), 'aria-label': lnoStr}, []),
     ]);
   },
   _render: function() {

--- a/web/htdocs/assets/js/codesearch_ui.js
+++ b/web/htdocs/assets/js/codesearch_ui.js
@@ -1,6 +1,8 @@
 $(function() {
 "use strict";
 
+var h = new HTMLFactory();
+
 function vercmp(a, b) {
   var re = /^([0-9]*)([^0-9]*)(.*)$/;
   var abits, bbits;
@@ -45,9 +47,82 @@ function shorten(ref) {
   return ref;
 }
 
-var Match = Backbone.Model.extend({
+var MatchView = Backbone.View.extend({
+  tagName: 'div',
   initialize: function() {
+    this.model.on('change', this.render, this);
   },
+  render: function() {
+    var div = this._render();
+    this.setElement(div);
+    return this;
+  },
+  _render: function() {
+    var i;
+    var ctx_before = [], ctx_after = [];
+    var lno = this.model.get('lno');
+    var ctxBefore = this.model.get('context_before'), clip_before = this.model.get('clip_before');
+    var ctxAfter = this.model.get('context_after'), clip_after = this.model.get('clip_after');
+
+    var lines_to_display_before = Math.max(0, ctxBefore.length - (clip_before || 0));
+    for (i = 0; i < lines_to_display_before; i ++) {
+      ctx_before.unshift(h.div([
+                                 h.span({cls: 'lno'}, [(lno - i - 1).toString(), "-"]),
+                                 this.model.get('context_before')[i]
+                               ]));
+    }
+    var lines_to_display_after = Math.max(0, ctxAfter.length - (clip_after || 0));
+    for (i = 0; i < lines_to_display_after; i ++) {
+      ctx_after.push(h.div([
+                             h.span({cls: 'lno'}, [(lno + i + 1).toString(), "-"]),
+                             this.model.get('context_after')[i]
+                           ]));
+    }
+    var line = this.model.get('line');
+    var bounds = this.model.get('bounds');
+    var pieces = [line.substring(0, bounds[0]),
+                  line.substring(bounds[0], bounds[1]),
+                  line.substring(bounds[1])];
+
+    var classes = ['match'];
+    if(clip_before !== undefined) classes.push('clip-before');
+    if(clip_after !== undefined) classes.push('clip-after');
+
+    var browseUrl = this.model.url();
+
+    var matchElement = h.a({cls: classes.join(' '), href: browseUrl}, [
+        h.div({cls: 'contents'}, [
+                ctx_before,
+                h.div({cls: 'matchline'}, [
+                  h.span({cls: 'lno'}, [lno + ":"]),
+                  pieces[0],
+                  h.span({cls: 'matchstr'}, [pieces[1]]),
+                  pieces[2]
+                ]),
+                ctx_after])]);
+
+    return matchElement;
+  }
+});
+
+/**
+ * A Match represents a single match in the code base.
+ *
+ * This model wraps the JSON response from the Codesearch backend for an individual match.
+ */
+var Match = Backbone.Model.extend({
+  path_info: function() {
+    var tree = this.get('tree');
+    var version = this.get('version');
+    var path = this.get('path');
+    return {
+      id: tree + ':' + version + ':' + path,
+      tree: tree,
+      version: version,
+      path: path,
+    }
+  },
+
   url: function() {
     var name = this.get('tree');
     var ref = this.get('version');
@@ -72,76 +147,78 @@ var Match = Backbone.Model.extend({
   }
 });
 
-var MatchView = Backbone.View.extend({
-  tagName: 'div',
-  initialize: function() {
-    this.model.on('change', this.render, this);
+/** A set of Matches at a single path. */
+var FileGroup = Backbone.Model.extend({
+  initialize: function(path_info) {
+    // The id attribute is used by collections to fetch models
+    this.id = path_info.id;
+    this.path_info = path_info;
+    this.matches = [];
   },
-  render: function() {
-    var div = this._render();
-    this.$el.empty();
-    this.$el.append(div);
-    return this;
+
+  add_match: function(match) {
+    this.matches.push(match);
   },
-  _render: function() {
-    var h = new HTMLFactory();
-    var i;
-    var lnos = [];
-    var matchlno = this.model.get('lno');
-    var lines = [];
-    // Context_before is actually in reverse order...
-    for (i = 0; i < this.model.get('context_before').length; i ++) {
-      var cells = [];
-      cells.push(h.td({cls: 'lno', line_number: matchlno-(i+1)},[]));
-      cells.push(h.td({cls: 'line'},[this.model.get('context_before')[i]]));
-      lines.unshift(h.tr({cls: 'row'},cells));
+
+  /** Prepare the matches for rendering by clipping the context of matches to avoid duplicate
+   *  lines being displayed in the search results.
+   *
+   * This function operates under these assumptions:
+   * - The matches are all for the same file
+   * - Two matches cannot have the same line number
+   */
+  process_context_overlaps: function() {
+    if(!(this.matches) || this.matches.length < 2) {
+      return; // We don't have overlaps unless we have at least two things
     }
 
-    var matchCells = [];
-    // Bringing lno up to the actual match's line number
-    var line = this.model.get('line');
-    var bounds = this.model.get('bounds');
-    var pieces = [line.substring(0, bounds[0]),
-                  line.substring(bounds[0], bounds[1]),
-                  line.substring(bounds[1])];
-    matchCells.push(h.td({cls: 'lno matchline', line_number: matchlno}, []));
-    matchCells.push(h.td({cls: 'line matchline'}, [
-                  pieces[0],
-                  h.span({cls: 'matchstr'}, [pieces[1]]),
-                  pieces[2]
-                ]));
-    lines.push(h.tr({cls: 'matchrow row'},matchCells));
+    // NOTE: The logic below requires matches to be sorted by line number.
+    this.matches.sort(function(a, b) {
+      return a.get('lno') - b.get('lno');
+    });
 
-    for (i = 0; i < this.model.get('context_after').length; i ++) {
-      var cells = [];
-      cells.push(h.td({cls: 'lno', line_number: matchlno+(i+1)},[]));
-      cells.push(h.td({cls: 'line'},[this.model.get('context_after')[i]]));
-      lines.push(h.tr({cls: 'row'},cells));
+    for(var i = 1, len = this.matches.length; i < len; i++) {
+      var previous_match = this.matches[i - 1], this_match = this.matches[i];
+      var last_line_of_prev_context = previous_match.get('lno') + previous_match.get('context_after').length;
+      var first_line_of_this_context = this_match.get('lno') - this_match.get('context_before').length;
+      var num_intersecting_lines = (last_line_of_prev_context - first_line_of_this_context) + 1;
+      if(num_intersecting_lines >= 0) {
+        // The matches are intersecting or share a boundary.
+        // Split the context between the previous match and this one. Uneven splits should leave
+        // the latter element with the larger piece.
+        var clip_for_previous = parseInt(Math.ceil(num_intersecting_lines / 2.0), 10);
+        var clip_for_this = parseInt(Math.floor(num_intersecting_lines / 2.0), 10);
+        previous_match.set('clip_after', clip_for_previous);
+        this_match.set('clip_before', clip_for_this);
+      } else {
+        previous_match.unset('clip_after');
+        this_match.unset('clip_before');
+      }
     }
-
-    var tree = this.model.get('tree');
-    var version = this.model.get('version');
-    var repoLabel = [
-      tree ? (tree + ":") : "",
-      shorten(version),
-      ":",
-      this.model.get('path'),
-      " - line " + matchlno + "" ];
-    var url = this.model.url();
-    if (url !== null) {
-      repoLabel = [ h.a({href: this.model.url()}, repoLabel) ];
-    }
-    return h.div({cls: 'match'}, [
-        h.div({}, [
-          h.span({cls: 'label'}, repoLabel)]),
-        h.div({cls: 'contents'}, [
-          h.table({cls: 'code'}, lines),
-          ])]);
   }
 });
 
-var MatchSet = Backbone.Collection.extend({
-  model: Match
+/** A set of matches that are automatically grouped by path. */
+var SearchResultSet = Backbone.Collection.extend({
+  comparator: function(file_group) {
+    return file_group.id;
+  },
+
+  add_match: function(match) {
+    var path_info = match.path_info();
+    var file_group = this.get(path_info.id);
+    if(!file_group) {
+      file_group = new FileGroup(path_info);
+      this.add(file_group);
+    }
+    file_group.add_match(match);
+  },
+
+  num_matches: function() {
+    return this.reduce(function(memo, file_group) {
+      return memo + file_group.matches.length;
+    }, 0);
+  }
 });
 
 var SearchState = Backbone.Model.extend({
@@ -156,7 +233,7 @@ var SearchState = Backbone.Model.extend({
 
   initialize: function() {
     this.search_map = {};
-    this.matches = new MatchSet();
+    this.search_results = new SearchResultSet();
     this.search_id = 0;
     this.on('change:displaying', this.new_search, this);
   },
@@ -167,7 +244,7 @@ var SearchState = Backbone.Model.extend({
         time: null,
         why: null
     });
-    this.matches.reset();
+    this.search_results.reset();
     for (var k in this.search_map) {
       if (parseInt(k) < this.get('displaying'))
         delete this.search_map[k];
@@ -231,27 +308,66 @@ var SearchState = Backbone.Model.extend({
     this.set('displaying', search);
     var m = _.clone(match);
     m.backend = this.search_map[search].backend;
-    this.matches.add(m);
+    this.search_results.add_match(new Match(m));
   },
   handle_done: function (search, time, why) {
     this.set('displaying', search);
     this.set({time: time, why: why});
+    this.search_results.trigger('search-complete');
+  }
+});
+
+var FileGroupView = Backbone.View.extend({
+  tagName: 'div',
+
+  render_header: function(tree, version, path) {
+    var basename, dirname;
+    var indexOfLastPathSep = path.lastIndexOf('/');
+
+    if(indexOfLastPathSep !== -1) {
+      basename = path.substring(indexOfLastPathSep + 1, path.length);
+      dirname = path.substring(0, indexOfLastPathSep + 1);
+    } else {
+      basename = path; // path doesn't contain any dir parts, only the basename
+      dirname = '';
+    }
+
+    var repoLabel = [
+      h.span({cls: "repo"}, [tree, ':']),
+      h.span({cls: "version"}, [shorten(version), ':']),
+      dirname,
+      h.span({cls: "filename"}, [basename])
+    ];
+    return h.span({cls: 'label header'}, repoLabel);
+  },
+
+  render: function() {
+    var matches = this.model.matches;
+    var el = this.$el;
+    el.empty();
+    el.append(this.render_header(this.model.path_info.tree, this.model.path_info.version, this.model.path_info.path));
+    matches.forEach(function(match) {
+      el.append(
+        new MatchView({model:match}).render().el
+      );
+    });
+    el.addClass('file-group');
+    return this;
   }
 });
 
 var MatchesView = Backbone.View.extend({
   el: $('#results'),
   initialize: function() {
-    this.model.matches.bind('add', this.add_one, this);
-    this.model.matches.bind('reset', this.add_all, this);
+    this.model.search_results.on('search-complete', this.render, this);
   },
-  add_one: function(model) {
-    var view = new MatchView({model: model});
-    this.$el.append(view.render().el);
-  },
-  add_all: function() {
+  render: function() {
     this.$el.empty();
-    this.model.matches.each(this.add_one);
+    this.model.search_results.each(function(file_group) {
+      file_group.process_context_overlaps();
+      var view = new FileGroupView({model: file_group});
+      this.$el.append(view.render().el);
+    }, this);
   }
 });
 
@@ -266,7 +382,7 @@ var ResultView = Backbone.View.extend({
     this.last_url  = null;
 
     this.model.on('all', this.render, this);
-    this.model.matches.on('all', this.render, this);
+    this.model.search_results.on('all', this.render, this);
   },
 
   render: function() {
@@ -302,7 +418,7 @@ var ResultView = Backbone.View.extend({
       this.$('#searchtimebox').hide();
     }
 
-    var results = '' + this.model.matches.size();
+    var results = '' + this.model.search_results.num_matches();
     if (this.model.get('why') === 'limit')
       results = results + '+';
     this.results.text(results);

--- a/web/htdocs/assets/js/codesearch_ui.js
+++ b/web/htdocs/assets/js/codesearch_ui.js
@@ -57,6 +57,9 @@ var MatchView = Backbone.View.extend({
     this.setElement(div);
     return this;
   },
+  _renderLno: function(n, isMatch) {
+    return h.a({cls: 'lno', href: this.model.url()}, [n.toString(), isMatch ? ":" : "-"]);
+  },
   _render: function() {
     var i;
     var ctx_before = [], ctx_after = [];
@@ -67,14 +70,14 @@ var MatchView = Backbone.View.extend({
     var lines_to_display_before = Math.max(0, ctxBefore.length - (clip_before || 0));
     for (i = 0; i < lines_to_display_before; i ++) {
       ctx_before.unshift(h.div([
-                                 h.span({cls: 'lno'}, [(lno - i - 1).toString(), "-"]),
+                                 this._renderLno(lno - i - 1, false),
                                  this.model.get('context_before')[i]
                                ]));
     }
     var lines_to_display_after = Math.max(0, ctxAfter.length - (clip_after || 0));
     for (i = 0; i < lines_to_display_after; i ++) {
       ctx_after.push(h.div([
-                             h.span({cls: 'lno'}, [(lno + i + 1).toString(), "-"]),
+                             this._renderLno(lno + i + 1, false),
                              this.model.get('context_after')[i]
                            ]));
     }
@@ -88,13 +91,11 @@ var MatchView = Backbone.View.extend({
     if(clip_before !== undefined) classes.push('clip-before');
     if(clip_after !== undefined) classes.push('clip-after');
 
-    var browseUrl = this.model.url();
-
-    var matchElement = h.a({cls: classes.join(' '), href: browseUrl}, [
+    var matchElement = h.div({cls: classes.join(' ')}, [
         h.div({cls: 'contents'}, [
                 ctx_before,
                 h.div({cls: 'matchline'}, [
-                  h.span({cls: 'lno'}, [lno + ":"]),
+                  this._renderLno(lno, true),
                   pieces[0],
                   h.span({cls: 'matchstr'}, [pieces[1]]),
                   pieces[2]
@@ -338,7 +339,7 @@ var FileGroupView = Backbone.View.extend({
       dirname,
       h.span({cls: "filename"}, [basename])
     ];
-    return h.span({cls: 'label header'}, repoLabel);
+    return h.a({cls: 'label header', href: this.model.matches[0].url()}, repoLabel);
   },
 
   render: function() {

--- a/web/htdocs/assets/js/codesearch_ui.js
+++ b/web/htdocs/assets/js/codesearch_ui.js
@@ -185,10 +185,19 @@ var FileGroup = Backbone.Model.extend({
       var num_intersecting_lines = (last_line_of_prev_context - first_line_of_this_context) + 1;
       if(num_intersecting_lines >= 0) {
         // The matches are intersecting or share a boundary.
-        // Split the context between the previous match and this one. Uneven splits should leave
-        // the latter element with the larger piece.
-        var clip_for_previous = parseInt(Math.ceil(num_intersecting_lines / 2.0), 10);
-        var clip_for_this = parseInt(Math.floor(num_intersecting_lines / 2.0), 10);
+        // Try to split the context between the previous match and this one.
+        // Uneven splits should leave the latter element with the larger piece.
+
+        // split_at will be the first line number grouped with the latter element.
+        var split_at = parseInt(Math.ceil((previous_match.get('lno') + this_match.get('lno')) / 2.0), 10);
+        if (split_at < first_line_of_this_context) {
+            split_at = first_line_of_this_context;
+        } else if (last_line_of_prev_context + 1 < split_at) {
+            split_at = last_line_of_prev_context + 1;
+        }
+
+        var clip_for_previous = last_line_of_prev_context - (split_at - 1);
+        var clip_for_this = split_at - first_line_of_this_context;
         previous_match.set('clip_after', clip_for_previous);
         this_match.set('clip_before', clip_for_this);
       } else {

--- a/web/htdocs/assets/js/codesearch_ui.js
+++ b/web/htdocs/assets/js/codesearch_ui.js
@@ -72,16 +72,16 @@ var MatchView = Backbone.View.extend({
 
     var lines_to_display_before = Math.max(0, ctxBefore.length - (clip_before || 0));
     for (i = 0; i < lines_to_display_before; i ++) {
-      ctx_before.unshift(h.div([
+      ctx_before.unshift(h.div({cls: 'line'}, [
                                  this._renderLno(lno - i - 1, false),
-                                 this.model.get('context_before')[i]
+                                 h.span([this.model.get('context_before')[i]]),
                                ]));
     }
     var lines_to_display_after = Math.max(0, ctxAfter.length - (clip_after || 0));
     for (i = 0; i < lines_to_display_after; i ++) {
-      ctx_after.push(h.div([
+      ctx_after.push(h.div({cls: 'line'}, [
                              this._renderLno(lno + i + 1, false),
-                             this.model.get('context_after')[i]
+                             h.span([this.model.get('context_after')[i]]),
                            ]));
     }
     var line = this.model.get('line');
@@ -97,11 +97,9 @@ var MatchView = Backbone.View.extend({
     var matchElement = h.div({cls: classes.join(' ')}, [
         h.div({cls: 'contents'}, [
                 ctx_before,
-                h.div({cls: 'matchline'}, [
+                h.div({cls: 'line matchline'}, [
                   this._renderLno(lno, true),
-                  pieces[0],
-                  h.span({cls: 'matchstr'}, [pieces[1]]),
-                  pieces[2]
+                  h.span([pieces[0], h.span({cls: 'matchstr'}, [pieces[1]]), pieces[2]]),
                 ]),
                 ctx_after])]);
 

--- a/web/htdocs/assets/js/codesearch_ui.js
+++ b/web/htdocs/assets/js/codesearch_ui.js
@@ -58,7 +58,7 @@ var MatchView = Backbone.View.extend({
     return this;
   },
   _renderLno: function(n, isMatch) {
-    return h.a({cls: 'lno', href: this.model.url()}, [n.toString(), isMatch ? ":" : "-"]);
+    return h.a({cls: 'lno', href: this.model.url(n)}, [n.toString(), isMatch ? ":" : "-"]);
   },
   _render: function() {
     var i;
@@ -124,7 +124,7 @@ var Match = Backbone.Model.extend({
     }
   },
 
-  url: function() {
+  url: function(lno) {
     var name = this.get('tree');
     var ref = this.get('version');
 
@@ -138,9 +138,13 @@ var Match = Backbone.Model.extend({
       return null;
     }
 
+    if (lno === undefined) {
+        lno = this.get('lno');
+    }
+
     // the order of these replacements is used to minimize conflicts
     var url = repo_map[name];
-    url = url.replace('{lno}', this.get('lno'));
+    url = url.replace('{lno}', lno);
     url = url.replace('{version}', shorten(ref));
     url = url.replace('{name}', name);
     url = url.replace('{path}', this.get('path'));

--- a/web/htdocs/assets/js/codesearch_ui.js
+++ b/web/htdocs/assets/js/codesearch_ui.js
@@ -58,7 +58,10 @@ var MatchView = Backbone.View.extend({
     return this;
   },
   _renderLno: function(n, isMatch) {
-    return h.a({cls: 'lno', href: this.model.url(n)}, [n.toString(), isMatch ? ":" : "-"]);
+    var lnoStr = n.toString() + (isMatch ? ":" : "-");
+    return h.a({cls: 'lno-link', href: this.model.url(n)}, [
+      h.span({cls: 'lno', 'aria-label': lnoStr}, []),
+    ]);
   },
   _render: function() {
     var i;


### PR DESCRIPTION
This was originally authored by @christoffer on an old fork of livegrep; I've taken his code, dropped it onto the modern livegrep mainline, and lightly tweaked a few things.

This is a significant change to the search result UI, so I recommend playing with it a bit to see how you like it. I think the most notable change in terms of user interaction is that the click-through link is the result snippet itself, rather than the header with repo/filename, so it's now impossible to copy text directly from the result snippet.

![screenshot 2017-05-23 21 57 10](https://cloud.githubusercontent.com/assets/376107/26387517/229b4508-4003-11e7-91d5-56029152c783.png)