### PR TITLE
Integrated file search

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -99,7 +99,10 @@ func (s *server) doSearch(ctx context.Context, backend *Backend, q *pb.Query) (*
 		return nil, err
 	}
 
-	reply := &api.ReplySearch{Results: make([]*api.Result, 0)}
+	reply := &api.ReplySearch{
+		Results:     make([]*api.Result, 0),
+		FileResults: make([]*api.FileResult, 0),
+	}
 
 	for _, r := range search.Results {
 		reply.Results = append(reply.Results, &api.Result{
@@ -111,6 +114,15 @@ func (s *server) doSearch(ctx context.Context, backend *Backend, q *pb.Query) (*
 			ContextAfter:  stringSlice(r.ContextAfter),
 			Bounds:        [2]int{int(r.Bounds.Left), int(r.Bounds.Right)},
 			Line:          r.Line,
+		})
+	}
+
+	for _, r := range search.FileResults {
+		reply.FileResults = append(reply.FileResults, &api.FileResult{
+			Tree:    r.Tree,
+			Version: r.Version,
+			Path:    r.Path,
+			Bounds:  [2]int{int(r.Bounds.Left), int(r.Bounds.Right)},
 		})
 	}
 

--- a/server/api/types.go
+++ b/server/api/types.go
@@ -12,8 +12,9 @@ type ReplyError struct {
 
 // ReplySearch is returned to /api/v1/search/:backend
 type ReplySearch struct {
-	Info    *Stats    `json:"info"`
-	Results []*Result `json:"results"`
+	Info        *Stats        `json:"info"`
+	Results     []*Result     `json:"results"`
+	FileResults []*FileResult `json:"file_results"`
 }
 
 type Stats struct {
@@ -34,4 +35,11 @@ type Result struct {
 	ContextAfter  []string `json:"context_after"`
 	Bounds        [2]int   `json:"bounds"`
 	Line          string   `json:"line"`
+}
+
+type FileResult struct {
+	Tree    string `json:"tree"`
+	Version string `json:"version"`
+	Path    string `json:"path"`
+	Bounds  [2]int `json:"bounds"`
 }

--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -202,11 +202,9 @@ public:
         struct job {
             std::string trace_id;
             atomic_int pending;
-            atomic_int file_pending;
             searcher *search;
             filename_searcher *file_search;
             thread_queue<chunk*> chunks;
-            thread_queue<indexed_file*> files;
         };
 
         const code_searcher *cs_;
@@ -239,8 +237,19 @@ protected:
     // Timestamp representing the end of index construction.
     int64_t index_timestamp_;
 
+    // Structures for fast filename search; somewhat similar to a single chunk.
+    // Built from files_ at finalization, not serialized or anything like that.
+    unsigned char *filename_data_;
+    int filename_data_size_;
+    uint32_t *filename_suffixes_;
+    // pairs (i, file), where file->path starts at filename_data_[i]
+    vector<pair<int, indexed_file*>> filename_positions_;
+
     vector<indexed_tree*> trees_;
     vector<indexed_file*> files_;
+
+private:
+    void index_filenames();
 
     friend class search_thread;
     friend class searcher;

--- a/src/dump_load.cc
+++ b/src/dump_load.cc
@@ -471,6 +471,8 @@ void load_allocator::load(code_searcher *cs) {
     assert(fstat(fd_, &st) == 0);
     cs->index_timestamp_ = st.st_mtime;
 
+    cs->index_filenames();
+
     cs->finalized_ = true;
 }
 

--- a/src/proto/livegrep.proto
+++ b/src/proto/livegrep.proto
@@ -28,6 +28,13 @@ message SearchResult {
     string line = 8;
 }
 
+message FileResult {
+    string tree = 1;
+    string version = 2;
+    string path = 3;
+    Bounds bounds = 4;
+}
+
 message SearchStats {
     int64 re2_time = 1;
     int64 git_time = 2;
@@ -58,6 +65,7 @@ message ServerInfo {
 message CodeSearchResult {
     SearchStats stats = 1;
     repeated SearchResult results = 2;
+    repeated FileResult file_results = 3;
 }
 
 message InfoRequest {

--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -150,6 +150,8 @@ void listen_grpc(code_searcher *search, code_searcher *tags, const string& addr)
     builder.RegisterService(service.get());
     std::unique_ptr<Server> server(builder.BuildAndStart());
 
+    log("Serving...");
+
     if (FLAGS_reload_rpc) {
         thread shutdown_thread([&]() {
             reload_request.get_future().wait();

--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -73,6 +73,10 @@ a:hover {
     margin-top: 10px;
 }
 
+.path-results {
+    margin-bottom: 15px;
+}
+
 .file-group {
     background: rgba(34, 76, 89, 0.05);
     margin-bottom: 15px;
@@ -81,19 +85,22 @@ a:hover {
 }
 
 .file-group .header {
-    color: #3d464d;
-    font-family: monospace;
-    font-weight: normal;
     display: block;
     background: rgba(0, 126, 229, 0.04);
     padding: 3px 5px;
 }
 
-.file-group .header .filename {
+.result-path {
+    color: #3d464d;
+    font-family: monospace;
+    font-weight: normal;
+}
+
+.result-path .filename {
     font-weight: bold;
 }
 
-.file-group .header .repo, .file-group .header .version {
+.result-path .repo, .result-path .version {
     color: rgba(0, 0, 0, 0.5);
 }
 

--- a/web/htdocs/assets/js/codesearch.js
+++ b/web/htdocs/assets/js/codesearch.js
@@ -39,6 +39,9 @@ var Codesearch = function() {
         data.results.forEach(function (r) {
           Codesearch.delegate.match(opts.id, r);
         });
+        data.file_results.forEach(function (r) {
+          Codesearch.delegate.file_match(opts.id, r);
+        });
         Codesearch.delegate.search_done(opts.id, elapsed, data.info.why);
       });
       xhr.error(function(data) {

--- a/web/htdocs/assets/js/codesearch_ui.js
+++ b/web/htdocs/assets/js/codesearch_ui.js
@@ -420,7 +420,12 @@ var SearchState = Backbone.Model.extend({
     this.set('displaying', search);
     var fm = _.clone(file_match);
     fm.backend = this.search_map[search].backend;
-    this.file_search_results.add(new FileMatch(fm));
+    // TODO: Currently we hackily limit the display to 10 file-path results.
+    // We should do something nicer, like a "..." the user can click to extend
+    // the list.
+    if (this.file_search_results.length < 10) {
+        this.file_search_results.add(new FileMatch(fm));
+    }
   },
   handle_done: function (search, time, why) {
     this.set('displaying', search);


### PR DESCRIPTION
Run the input query against file paths as well as file contents, and show matches before the main results.

The filename index isn't stored in the on-disk format, but only held in memory, and rebuilt every time the index is loaded. On our corpus this adds about 2.5s of startup time.

I'm not totally happy with the code quality (copied JS; crudely refactored suffix_search function) or the UX (probably want a shorter list of filename results and some heuristics on whether they're interesting to display), but it's a start!

Fixes #17.