### PR TITLE
Add rudimentary stats reporting

### DIFF
--- a/server/backend.go
+++ b/server/backend.go
@@ -21,6 +21,7 @@ type I struct {
 	Name  string
 	Trees []Tree
 	sync.Mutex
+	IndexTime time.Time
 }
 
 type Backend struct {
@@ -69,6 +70,7 @@ func (bk *Backend) refresh(info *pb.ServerInfo) {
 	if info.Name != "" {
 		bk.I.Name = info.Name
 	}
+	bk.I.IndexTime = time.Unix(info.IndexTime, 0)
 	if len(info.Trees) > 0 {
 		bk.I.Trees = nil
 		for _, r := range info.Trees {

--- a/src/codesearch.cc
+++ b/src/codesearch.cc
@@ -384,6 +384,11 @@ void code_searcher::finalize() {
     assert(!finalized_);
     finalized_ = true;
     alloc_->finalize();
+
+    timeval now;
+    gettimeofday(&now, NULL);
+    index_timestamp_ = now.tv_sec;
+
     idx_data_chunks.inc(alloc_->end() - alloc_->begin());
     idx_content_chunks.inc(alloc_->end_content() - alloc_->begin_content());
 }

--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -163,6 +163,10 @@ public:
         return files_.end();
     }
 
+    int64_t index_timestamp() {
+        return index_timestamp_;
+    }
+
     class search_thread {
     public:
         search_thread(code_searcher *cs);
@@ -214,6 +218,9 @@ protected:
     // Indicates that everything all is ready for searching--we are done creating
     // index or initializing it from a file.
     bool finalized_;
+
+    // Timestamp representing the end of index construction.
+    int64_t index_timestamp_;
 
     vector<indexed_tree*> trees_;
     vector<indexed_file*> files_;

--- a/src/dump_load.cc
+++ b/src/dump_load.cc
@@ -467,6 +467,10 @@ void load_allocator::load(code_searcher *cs) {
     }
     assert(it == cs->files_.end());
 
+    struct stat st;
+    assert(fstat(fd_, &st) == 0);
+    cs->index_timestamp_ = st.st_mtime;
+
     cs->finalized_ = true;
 }
 

--- a/src/proto/livegrep.proto
+++ b/src/proto/livegrep.proto
@@ -51,6 +51,8 @@ message ServerInfo {
     }
     repeated Tree trees = 2;
     bool has_tags = 3;
+    // unix timestamp (seconds)
+    int64 index_time = 4;
 }
 
 message CodeSearchResult {

--- a/src/tools/grpc_server.cc
+++ b/src/tools/grpc_server.cc
@@ -102,6 +102,7 @@ Status CodeSearchImpl::Info(ServerContext* context, const ::InfoRequest* request
         }
     }
     response->set_has_tags(tagdata_ != nullptr);
+    response->set_index_time(cs_->index_timestamp());
     return Status::OK;
 }
 


### PR DESCRIPTION
 - Create a /debug/stats route
 - Include index creation time in Info RPC result
 - Report index age as a stat

It's not clear whether this is the right long-term approach for stats (maybe we'd rather speak statsd or something?).