### PR TITLE
Minor css change to allow users to highlight the file path more easily.

### DIFF
--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -78,15 +78,14 @@ a:hover {
 }
 
 .file-group {
-    background: rgba(34, 76, 89, 0.05);
+    background: rgba(19, 61, 153, 0.09);   
     margin-bottom: 15px;
     border: solid 1px rgba(0, 0, 0, 0.1);
     border-left: solid 3px #A0D1FA;
 }
 
 .file-group .header {
-    display: block;
-    background: rgba(0, 126, 229, 0.04);
+    display: inline-block;
     padding: 3px 5px;
 }
 


### PR DESCRIPTION
Currently, the '\<a\>' tag takes up the entire length of the header div.
This means that you can't highlight the file path if you click down
and drag left to highlight the path from the right.

This change makes the <a> tag take up only the minimum width needed,
allowing highlighting to work as expected. The background color
change is done to merge the two backgrounds and produce the same
color as before.
