### PR TITLE
If custom header content is provided, replace the default header

### DIFF
--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -162,6 +162,7 @@ a:hover {
     width: 60em;
     margin: auto;
     color: #999;
+    padding-bottom: 100px;
 }
 
 .helpsection {
@@ -171,6 +172,12 @@ a:hover {
 
 #helparea table {
     width: 100%;
+}
+
+.credit {
+    text-align: center;
+    font-size: smaller;
+    color: #999;
 }
 
 .label {
@@ -270,6 +277,10 @@ a:hover {
     float: right;
 }
 
+#header ul {
+    padding: 0;
+}
+
 #header li {
     display: inline;
 }
@@ -290,8 +301,9 @@ a:hover {
 #header {
     font-size: 80%;
     color: #999;
-    margin: auto;
+    margin: 1em auto;
     width: 40em;
+    text-align: center;
 }
 
 #permalink {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -117,4 +117,7 @@
   <div id='results'>
   </div>
 </div>
+<p class='credit'>
+Livegrep project &copy; Nelson Elhage
+</p>
 </div>

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -34,22 +34,21 @@
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Stripe Code Search" />
   </head>
   <body>
-    <div id='customization'>
-    {{if .Config.HeaderHTML}}
-    {{.Config.HeaderHTML}}
-    {{end}}
-    </div>
     {{if .IncludeHeader}}
     <div id='header'>
-      <ul>
-        <li><a href="/">search</a></li>
-        <li><a href="/about">about</a></li>
-        <li><a href="https://github.com/livegrep/livegrep">source</a></li>
-        {{if .Config.Feedback.MailTo}}
-        <li><a id='feedbacklink' href="mailto:{{.Config.Feedback.MailTo}}">feedback</a></li>
-        {{end}}
-        <li class='first'>livegrep is a project by <a href="http://blog.nelhage.com/">Nelson Elhage</a></li>
-      </ul>
+      {{if .Config.HeaderHTML}}
+        {{.Config.HeaderHTML}}
+      {{else}}
+        <ul>
+          <li><a href="/">search</a></li>
+          <li><a href="/about">about</a></li>
+          <li><a href="https://github.com/livegrep/livegrep">source</a></li>
+          {{if .Config.Feedback.MailTo}}
+          <li><a id='feedbacklink' href="mailto:{{.Config.Feedback.MailTo}}">feedback</a></li>
+          {{end}}
+          <li class='first'>livegrep is a project by <a href="http://blog.nelhage.com/">Nelson Elhage</a></li>
+        </ul>
+      {{end}}
     </div>
     {{end}}
     {{ .Body}}


### PR DESCRIPTION
Since the tech-demo-style header from livegrep.com don't necessarily make sense for a corporate internal instance.