### PR TITLE
Hacky support for bare file: queries

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -181,10 +181,16 @@ func (s *server) ServeAPISearch(ctx context.Context, w http.ResponseWriter, r *h
 		return
 	}
 
-	if q.Line == "" {
+	if q.Line == "" && q.File == "" {
 		writeError(ctx, w, 400, "bad_query",
 			"You must specify a regex to match")
 		return
+	}
+
+	fileOnlySearch := false
+	if q.Line == "" && q.File != "" {
+		fileOnlySearch = true
+		q.Line = q.File
 	}
 
 	if q.MaxMatches == 0 {
@@ -192,6 +198,10 @@ func (s *server) ServeAPISearch(ctx context.Context, w http.ResponseWriter, r *h
 	}
 
 	reply, err := s.doSearch(ctx, backend, &q)
+
+	if fileOnlySearch {
+		reply.Results = []*api.Result{}
+	}
 
 	if err != nil {
 		log.Printf(ctx, "error in search err=%s", err)

--- a/web/htdocs/assets/js/codesearch_ui.js
+++ b/web/htdocs/assets/js/codesearch_ui.js
@@ -414,10 +414,12 @@ var SearchState = Backbone.Model.extend({
     this.set('displaying', search);
     var fm = _.clone(file_match);
     fm.backend = this.search_map[search].backend;
-    // TODO: Currently we hackily limit the display to 10 file-path results.
+    // TODO: Currently we very hackily limit the display to 10 file-path
+    // results, unless there are no normal results; then we show all the
+    // file-path results.
     // We should do something nicer, like a "..." the user can click to extend
     // the list.
-    if (this.file_search_results.length < 10) {
+    if (this.file_search_results.length < 10 || this.search_results.length == 0) {
         this.file_search_results.add(new FileMatch(fm));
     }
   },


### PR DESCRIPTION
I think ultimately the right path forward is to extend `codesearch` itself with some smarter behaviour. But this was too easy of a hack for me to pass up, just in case you want to take it :)

Fixes #89