### PR TITLE
Tweak max_matches behaviour

### DIFF
--- a/src/codesearch.cc
+++ b/src/codesearch.cc
@@ -52,7 +52,7 @@ DEFINE_bool(index, true, "Create a suffix-array index to speed searches.");
 DEFINE_bool(compress, true, "Compress file contents linewise");
 DEFINE_bool(drop_cache, false, "Drop caches before each search");
 DEFINE_bool(search, true, "Actually do the search.");
-DEFINE_int32(max_matches, 50, "The maximum number of results to return for a single query.");
+DEFINE_int32(max_matches, 50, "The default maximum number of results to return for a single query.");
 DEFINE_int32(timeout, 1000, "The number of milliseconds a single search may run for.");
 DEFINE_int32(threads, 4, "Number of threads to use.");
 DEFINE_int32(line_limit, 1024, "Maximum line length to index.");
@@ -116,7 +116,7 @@ public:
         if (FLAGS_max_matches && !query_max_matches) {
             max_matches_ = FLAGS_max_matches;
         } else {
-            max_matches_ = std::min(FLAGS_max_matches, query_max_matches);
+            max_matches_ = query_max_matches;
         }
 
         if (FLAGS_timeout <= 0) {

--- a/web/htdocs/assets/js/codesearch_ui.js
+++ b/web/htdocs/assets/js/codesearch_ui.js
@@ -543,7 +543,7 @@ var ResultView = Backbone.View.extend({
     }
 
     var results = '' + this.model.search_results.num_matches();
-    if (this.model.get('why') === 'MATCH_LIMIT')
+    if (this.model.get('why') !== 'NONE')
       results = results + '+';
     this.results.text(results);
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -100,6 +100,11 @@
       <td><a href="/search?q=hello+-repo:{{.SampleRepo}}">example</a></td>
     </tr>
     <tr>
+      <td><code>max_matches:</code></td>
+      <td>Adjust the limit on number of matching lines returned.</td>
+      <td><a href="/search?q=hello+max_matches:5">example</a></td>
+    </tr>
+    <tr>
       <td><code>(<em>special-term</em>:)</code></td>
       <td>Escape one of the above terms by wrapping it in parentheses (with regex enabled).</td>
       <td><a href="/search?q=(file:)&regex=true">example</a></td>


### PR DESCRIPTION
 - If `max_matches:` is provided in the query, use that as the limit,
   regardless of a limit passed on the `codesearch` command line. This
   is on the theory that, if the user provides a `max_matches` value
   greater than the configured limit, it's because they want to see more
   results. If they want to see a LOT of results and are willing to wait
   for it, that's their choice.
 - Any time the search completes early (without an exhaustive list of
   results), indicate that the count in the UI is not exact. Included in
   this change because we're making it easier to hit the time limit
   (rather than the match limit).
 - Mention `max_matches:` in the help section.