### PR TITLE
From file view, "enter" opens search in new tab

### DIFF
--- a/web/htdocs/assets/js/fileview.js
+++ b/web/htdocs/assets/js/fileview.js
@@ -9,11 +9,17 @@
     return window.getSelection ? window.getSelection().toString() : null;
   }
 
-  function doSearch(event, query) {
+  function doSearch(event, query, newTab) {
+    var url;
     if (query !== undefined) {
-      window.location.href = '/search?q=' + encodeURIComponent(query);
+      url = '/search?q=' + encodeURIComponent(query);
     } else {
-      window.location.href = '/search';
+      url = '/search';
+    }
+    if (newTab === true){
+      window.open(url);
+    } else {
+      window.location.href = url
     }
   }
 
@@ -172,7 +178,7 @@
         // Perform a new search with the selected text, if any
         var selectedText = getSelectedText();
         if(selectedText) {
-          doSearch(event, selectedText);
+          doSearch(event, selectedText, true);
         }
       } else if(event.which === KeyCodes.SLASH_OR_QUESTION_MARK) {
           event.preventDefault();

--- a/web/templates/fileview.html
+++ b/web/templates/fileview.html
@@ -54,8 +54,9 @@
       <ul>
         <li>Click on a line number to highlight it</li>
         <li>Shift + click a second line number to highlight a range</li>
-        <li>Press <pre class="keyboard-shortcut">/</pre> to start a new search (the selected text will be prefilled)</li>
-        <li>Select some text and press <pre class="keyboard-shortcut">enter</pre> to perform a new search with the selected text</li>
+        <li>Press <pre class="keyboard-shortcut">/</pre> to start a new search</li>
+        <li>Select some text and press <pre class="keyboard-shortcut">/</pre> to search for that text</li>
+        <li>Select some text and press <pre class="keyboard-shortcut">enter</pre> to search for that text in a new tab</li>
         <li>Press <pre class="keyboard-shortcut">v</pre> to view this file/directory at {{.ExternalDomain}}</li>
       </ul>
     </div>


### PR DESCRIPTION
This is meant to smooth the flow where a user wants to trace multiple
layers of a call stack, and then switch back and forth between
inspecting the function bodies.

The change will be a bit disruptive for users accustomed to "enter"
performing a search in the current tab; hopefully it shouldn't be too
hard for them to switch to "/".