### PR TITLE
Make frontend smarter about filename-only searches

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -123,6 +123,11 @@ func (s *server) doSearch(ctx context.Context, backend *Backend, q *pb.Query) (*
 	reply := &api.ReplySearch{
 		Results:     make([]*api.Result, 0),
 		FileResults: make([]*api.FileResult, 0),
+		SearchType:  "normal",
+	}
+
+	if q.FilenameOnly {
+		reply.SearchType = "filename_only"
 	}
 
 	for _, r := range search.Results {

--- a/server/api/types.go
+++ b/server/api/types.go
@@ -15,6 +15,7 @@ type ReplySearch struct {
 	Info        *Stats        `json:"info"`
 	Results     []*Result     `json:"results"`
 	FileResults []*FileResult `json:"file_results"`
+	SearchType  string        `json:"search_type"`
 }
 
 type Stats struct {

--- a/web/htdocs/assets/js/codesearch.js
+++ b/web/htdocs/assets/js/codesearch.js
@@ -46,7 +46,7 @@ var Codesearch = function() {
         data.file_results.forEach(function (r) {
           Codesearch.delegate.file_match(opts.id, r);
         });
-        Codesearch.delegate.search_done(opts.id, elapsed, data.info.why);
+        Codesearch.delegate.search_done(opts.id, elapsed, data.search_type, data.info.why);
       });
       xhr.error(function(data) {
         window._err = data;


### PR DESCRIPTION
Tell the frontend explicitly whether a search was filename-only or not;
if it was, render more results, and show the number of file results in
the UI.