### PR TITLE
Improve healthcheck slightly

### DIFF
--- a/server/backend.go
+++ b/server/backend.go
@@ -38,6 +38,7 @@ func NewBackend(id string, addr string) (*Backend, error) {
 	}
 	bk := &Backend{
 		Id:         id,
+		Addr:       addr,
 		I:          &I{Name: id},
 		Codesearch: pb.NewCodeSearchClient(client),
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -147,6 +147,16 @@ func (s *server) ServeHelp(ctx context.Context, w http.ResponseWriter, r *http.R
 }
 
 func (s *server) ServeHealthcheck(w http.ResponseWriter, r *http.Request) {
+	// All backends must have (at some point) reported an index age for us to
+	// report as healthy.
+	// TODO: report as unhealthy if a backend goes down after we've spoken to
+	// it.
+	for _, bk := range s.bk {
+		if bk.I.IndexTime.IsZero() {
+			http.Error(w, fmt.Sprintf("unhealthy backend '%s' '%s'\n", bk.Id, bk.Addr), 500)
+			return
+		}
+	}
 	io.WriteString(w, "ok\n")
 }
 


### PR DESCRIPTION
Previously, the healthcheck represented only the `livegrep` ability to
respond to requests. This extends the healthcheck to verify that
`livegrep` has ever been able to talk to all of its backends.