### PR TITLE
Text style refresh

### DIFF
--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -206,7 +206,8 @@ a:hover {
 
 .result-path {
     color: #3d464d;
-    font-family: monospace;
+    font-family: "Menlo", "Consolas", "Monaco", monospace;
+    font-size: 12px;
     font-weight: normal;
 }
 
@@ -248,7 +249,8 @@ a:hover {
     display: grid;
     grid-template-columns: 4em auto;
     white-space: pre-wrap;
-    font-family: monospace;
+    font-family: "Menlo", "Consolas", "Monaco", monospace;
+    font-size: 12px;
     padding: 10px 5px;
     color: #000;
     margin: 0;
@@ -299,7 +301,7 @@ a:hover {
 }
 
 .matchstr {
-    background: #FFFF00;
+    background: rgba(255, 234, 170, 0.75);
     font-weight: bold;
 }
 
@@ -344,10 +346,11 @@ a:hover {
 .file-viewer {
     border-collapse: collapse;
     margin: 0;
-    line-height: 1.3;
+    line-height: 1.2;
     width: 100%;
     overflow: visible; /* Allow code content to overflow */
-    font-family: monospace;
+    font-family: "Menlo", "Consolas", "Monaco", monospace;
+    font-size: 12px;
 }
 
 .file-viewer .header {
@@ -377,7 +380,7 @@ a:hover {
 }
 
 .file-viewer .header-title {
-    font-size: 14px;
+    font-size: 13px;
     padding: 0;
     margin: 0 0 5px 0;
     font-weight: normal;
@@ -392,7 +395,11 @@ a:hover {
 
 .file-viewer .file-content {
     position: relative;
-    font-family: monospace;
+}
+
+.file-viewer .file-content, .file-viewer .file-content code {
+    font-family: "Menlo", "Consolas", "Monaco", monospace;
+    font-size: 12px;
 }
 
 .file-viewer .line-numbers {
@@ -599,7 +606,8 @@ div.example {
 }
 
 .query {
-    font-family: monospace;
+    font-family: "Menlo", "Consolas", "Monaco", monospace;
+    font-size: 12px;
     font-weight: bold;
 }
 

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -9,7 +9,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.3.1/underscore-min.js" integrity="sha256-Qtj60TvCj8cmd1GW7Jq5U/6/m94XXFhFEoNhyVP6F/Q=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/0.9.2/backbone-min.js" integrity="sha256-tQjdUhE0MTzHcOzRUuotgnMrURWIamfdqwv1QWB57uk=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js" integrity="sha256-/BfiIkHlHoVihZdc6TFuj7MmJ0TWcWsMXkeDFwhi0zw=" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/tomorrow.min.css" integrity="sha256-0QU8ry64q+N6YBIEF/6XF6vUeF15gbNO4tLS6ikk0FI=" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/googlecode.min.css" integrity="sha256-arq4LfC7imzesljdi/Th/9Sws1lwfF/iq5a+A7oycTg=" crossorigin="anonymous" />
     {{if .ScriptData}}
     <script>
       window.scriptData = {{.ScriptData}};


### PR DESCRIPTION
 - Use `"Menlo", "Consolas", "Monaco", monospace` as fonts for source
   code and paths.
 - Change match highlight color, so it's distinguishable from
   typical browser search-in-page highlighting.
 - In the file-viewer, change highlight.js style to googlecode, and tweak
   line-height for slightly denser display.