### PR TITLE
Skip chunks that don't contain desired repos

### DIFF
--- a/src/chunk.cc
+++ b/src/chunk.cc
@@ -9,6 +9,7 @@
 #include "src/lib/metrics.h"
 
 #include "src/chunk.h"
+#include "src/codesearch.h"
 
 #include "divsufsort.h"
 #include "re2/re2.h"
@@ -109,7 +110,17 @@ void chunk::finalize_files() {
         ++out;
     }
     files.resize(out - files.begin());
+
+    build_tree_names();
     build_tree();
+}
+
+void chunk::build_tree_names() {
+    for (auto it = files.begin(); it != files.end(); it++) {
+        for (auto it2 = it->files.begin(); it2 != it->files.end(); it2++) {
+            tree_names.insert((*it2)->tree->name);
+        }
+    }
 }
 
 void chunk::build_tree() {

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <algorithm>
 #include <list>
+#include <set>
 
 #include <stdint.h>
 
@@ -75,6 +76,10 @@ struct chunk {
     // chunk's data. Sorted (and compacted) at the very end of index creation.
     vector<chunk_file> files;
 
+    // Collects the names of all trees indexed in this chunk, to enable
+    // short-circuiting based on a repo constraint.
+    set<string> tree_names;
+
     // Transient during index creation. Collects references to the file
     // currently being processed by the code_searcher, when that file contains
     // lines stored in this chunk's data. One the code_searcher finishes
@@ -106,6 +111,7 @@ struct chunk {
     void finish_file();
     void finalize();
     void finalize_files();
+    void build_tree_names();
     void build_tree();
 
     struct lt_suffix {

--- a/src/dump_load.cc
+++ b/src/dump_load.cc
@@ -409,6 +409,7 @@ void load_allocator::load_chunk(code_searcher *cs) {
         cf.left  = load_int32();
         cf.right = load_int32();
     }
+    chunk->build_tree_names();
     chunk->build_tree();
     ++next_chunk_;
 }


### PR DESCRIPTION
When indexing, codesearch builds chunks in the order that repositories
are listed in the configuration. When searching, it examines chunks in
the same order. This means that it finds results from repos in roughly
the order repos listed in the configuration (modulo multiple threads
concurrently processing chunks).

Since repo_pat constraints are applied after the main suffix array
search, this means that the search may examine and discard many
candidate lines before it ever reaches the desired repo, which can take
a long time. On our instance (17 repos, ~11GB index), restricting a
search like "e" to the last repo takes 6-7x as long as the same search
restricted to the first repo.

This change allows us to skip irrelevant chunks entirely. However,
the improvement in overall search performance is limited by the
unchunked filename search happening in parallel: even though the main
search completes more quickly, the RPC must still wait for the
filename search before returning results, so there's potential for
further improvement here.