### PR TITLE
Fetch static resources with content hashes

### DIFF
--- a/server/BUILD
+++ b/server/BUILD
@@ -31,6 +31,7 @@ go_library(
         '//web:htdocs',
         '//web:templates',
         '//web:webpack_build',
+        '//web:asset_hashes',
     ],
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -29,20 +29,27 @@ type Templates struct {
 }
 
 type server struct {
-	config  *config.Config
-	bk      map[string]*Backend
-	bkOrder []string
-	repos   map[string]config.RepoConfig
-	inner   http.Handler
-	T       Templates
-	Layout  *template.Template
+	config      *config.Config
+	bk          map[string]*Backend
+	bkOrder     []string
+	repos       map[string]config.RepoConfig
+	inner       http.Handler
+	T           Templates
+	AssetHashes map[string]string
+	Layout      *template.Template
 
 	honey *libhoney.Builder
 }
 
 func (s *server) loadTemplates() {
-	if e := templates.Load(path.Join(s.config.DocRoot, "templates"), &s.T); e != nil {
-		panic(fmt.Sprintf("loading templates: %v", e))
+	s.AssetHashes = make(map[string]string)
+	err := templates.Load(
+		path.Join(s.config.DocRoot, "templates"),
+		&s.T,
+		path.Join(s.config.DocRoot, "hashes.txt"),
+		s.AssetHashes)
+	if err != nil {
+		panic(fmt.Sprintf("loading templates: %v", err))
 	}
 }
 
@@ -297,7 +304,10 @@ func New(cfg *config.Config) (http.Handler, error) {
 	if cfg.Reload {
 		h = templates.ReloadHandler(
 			path.Join(srv.config.DocRoot, "templates"),
-			&srv.T, h)
+			&srv.T,
+			path.Join(srv.config.DocRoot, "hashes.txt"),
+			srv.AssetHashes,
+			h)
 	}
 
 	mux := http.NewServeMux()

--- a/server/templates.go
+++ b/server/templates.go
@@ -17,6 +17,7 @@ type page struct {
 	IncludeHeader bool
 	Body          template.HTML
 	Config        *config.Config
+	AssetHashes   map[string]string
 }
 
 type Template interface {
@@ -33,6 +34,7 @@ func executeTemplate(t Template, context interface{}) ([]byte, error) {
 
 func (s *server) renderPage(w io.Writer, p *page) {
 	p.Config = s.config
+	p.AssetHashes = s.AssetHashes
 	if e := s.T.Layout.Execute(w, p); e != nil {
 		log.Printf("Error rendering page=%q error=%q",
 			p.Title, e.Error())

--- a/server/templates/templates.go
+++ b/server/templates/templates.go
@@ -1,9 +1,13 @@
 package templates
 
 import (
+	"bufio"
+	"encoding/base64"
+	"encoding/hex"
 	"html/template"
 	"log"
 	"net/http"
+	"os"
 	"path"
 	"reflect"
 	"strings"
@@ -17,14 +21,33 @@ func templatePath(f reflect.StructField) string {
 	return strings.ToLower(f.Name) + ".html"
 }
 
+func linkTag(rel string, s string, m map[string]string) template.HTML {
+	hash := m[strings.TrimPrefix(s, "/")]
+	href := s + "?v=" + hash
+	hashBytes, _ := hex.DecodeString(hash)
+	integrity := "sha256-" + base64.StdEncoding.EncodeToString(hashBytes)
+	return template.HTML(`<link rel="` + rel + `" href="` + href + `" integrity="` + integrity + `" />`)
+}
+
+func scriptTag(s string, m map[string]string) template.HTML {
+	hash := m[strings.TrimPrefix(s, "/")]
+	href := s + "?v=" + hash
+	hashBytes, _ := hex.DecodeString(hash)
+	integrity := "sha256-" + base64.StdEncoding.EncodeToString(hashBytes)
+	return template.HTML(`<script src="` + href + `" integrity="` + integrity + `"></script>`)
+
+}
+
 func getFuncs() map[string]interface{} {
 	return map[string]interface{}{
 		"loop":      func(n int) []struct{} { return make([]struct{}, n) },
 		"toLineNum": func(n int) int { return n + 1 },
+		"linkTag":   linkTag,
+		"scriptTag": scriptTag,
 	}
 }
 
-func Load(base string, templates interface{}) error {
+func LoadTemplates(base string, templates interface{}) error {
 	v := reflect.ValueOf(templates)
 	if v.Kind() != reflect.Ptr {
 		panic("Load: Must provide pointer-to-struct")
@@ -61,18 +84,53 @@ func Load(base string, templates interface{}) error {
 	return nil
 }
 
-type reloadHandler struct {
-	baseDir string
-	t       interface{}
-	in      http.Handler
+func LoadAssetHashes(assetHashFile string, assetHashMap map[string]string) error {
+	file, err := os.Open(assetHashFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	for k := range assetHashMap {
+		delete(assetHashMap, k)
+	}
+
+	for scanner.Scan() {
+		pieces := strings.SplitN(scanner.Text(), "  ", 2)
+		hash := pieces[0]
+		asset := pieces[1]
+		(assetHashMap)[asset] = hash
+	}
+
+	return nil
 }
 
-func ReloadHandler(base string, templates interface{}, h http.Handler) http.Handler {
-	return &reloadHandler{base, templates, h}
+func Load(base string, templates interface{}, assetHashFile string, assetHashMap map[string]string) error {
+	if err := LoadTemplates(base, templates); err != nil {
+		return err
+	}
+	if err := LoadAssetHashes(assetHashFile, assetHashMap); err != nil {
+		return err
+	}
+	return nil
+}
+
+type reloadHandler struct {
+	baseDir       string
+	t             interface{}
+	assetHashFile string
+	assetHashMap  map[string]string
+	in            http.Handler
+}
+
+func ReloadHandler(base string, templates interface{}, assetHashFile string, assetHashMap map[string]string, h http.Handler) http.Handler {
+	return &reloadHandler{base, templates, assetHashFile, assetHashMap, h}
 }
 
 func (h *reloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	e := Load(h.baseDir, h.t)
+	e := Load(h.baseDir, h.t, h.assetHashFile, h.assetHashMap)
 	if e != nil {
 		log.Printf("loading templates: err=%v", e)
 	}

--- a/web/BUILD
+++ b/web/BUILD
@@ -29,3 +29,13 @@ webpack_build(
         '//web/3d:html',
     ],
 )
+
+genrule(
+    name = 'asset_hashes',
+    srcs = [
+        '//web:htdocs',
+        '//web:webpack_build',
+    ],
+    outs = ['hashes.txt'],
+    cmd = 'sha256sum $(SRCS) | sed "s_ bazel-out/local-fastbuild/bin/_ _" | sed "s_ web/htdocs/_ _"> $@',
+)

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -3,8 +3,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>{{.Title}}</title>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" />
-    <link rel="stylesheet" href='/assets/css/codesearch.css' />
+    {{linkTag "shortcut icon" "/assets/img/favicon.ico" .AssetHashes}}
+    {{linkTag "stylesheet" "/assets/css/codesearch.css" .AssetHashes}}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.7.1/jquery.min.js" integrity="sha256-iBcUE/x23aI6syuqF7EeT/+JFBxjPs5zeFJEXxumwb0=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.3.1/underscore-min.js" integrity="sha256-Qtj60TvCj8cmd1GW7Jq5U/6/m94XXFhFEoNhyVP6F/Q=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/0.9.2/backbone-min.js" integrity="sha256-tQjdUhE0MTzHcOzRUuotgnMrURWIamfdqwv1QWB57uk=" crossorigin="anonymous"></script>
@@ -20,7 +20,7 @@
       window.page = {{.ScriptName}};
     </script>
     {{end}}
-    <script language="javascript" type="text/javascript" src="/assets/js/bundle.js"></script>
+    {{scriptTag "/assets/js/bundle.js" .AssetHashes}}
     {{if .Config.Sentry.URI}}
     <script src="//cdn.ravenjs.com/1.1.15/jquery,native/raven.min.js"></script>
     <script>


### PR DESCRIPTION
This ensures that users don't see old cached versions of the javascript.

Enforcing subresource integrity here is probably unneeded, but we have
the information, so why not?