### PR TITLE
Add rudimentary search result ranking

### DIFF
--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -113,6 +113,7 @@ struct match_result {
     vector<StringPiece> context_after;
     StringPiece line;
     int matchleft, matchright;
+    int score;
 };
 
 struct file_result {

--- a/src/score.cc
+++ b/src/score.cc
@@ -1,0 +1,38 @@
+#include "src/lib/debug.h"
+#include "src/score.h"
+
+scorer::scorer(query *q) : query_(q) {}
+
+bool scorer::operator()(match_result *m) {
+    int score = score_match(query_, m);
+    m->score = score;
+    return true;
+}
+
+int score_match(const query *q, const match_result *m) {
+    // Simple scoring implementation based purely on query and filepath.
+    int score = 0;
+    if (m->file->path.find("generated") != string::npos ||
+            m->file->path.find("_pb2") != string::npos ||
+            m->file->path.find(".min.") != string::npos ||
+            m->file->path.find("/minified/") != string::npos ||
+            m->file->path.find("bundle") != string::npos) {
+        score -= 50;
+    }
+    if (m->file->path.find("/third_party/") != string::npos ||
+            m->file->path.find("/thirdparty/") != string::npos ||
+            m->file->path.find("/vendor/") != string::npos ||
+            m->file->path.find("/github.com/") != string::npos ||
+            m->file->path.find("/node_modules/") != string::npos) {
+        score -= 50;
+    }
+    if (m->file->path.find("test") != string::npos &&
+            !((q->line_pat && q->line_pat->pattern().find("test") != string::npos) ||
+              (q->file_pat && q->file_pat->pattern().find("test") != string::npos))) {
+        score -= 20;
+    }
+    if (q->line_pat && m->file->path.find(q->line_pat->pattern()) != string::npos) {
+        score += 200;
+    }
+    return score;
+}

--- a/src/score.h
+++ b/src/score.h
@@ -1,0 +1,12 @@
+#include "src/codesearch.h"
+
+class scorer {
+public:
+    scorer(query *q);
+    bool operator()(struct match_result *m);
+
+private:
+    query *query_;
+};
+
+int score_match(const query *q, const match_result* m);

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -183,9 +183,9 @@ var Match = Backbone.Model.extend({
 
 /** A set of Matches at a single path. */
 var FileGroup = Backbone.Model.extend({
-  initialize: function(path_info) {
+  initialize: function(id, path_info) {
     // The id attribute is used by collections to fetch models
-    this.id = path_info.id;
+    this.id = id;
     this.path_info = path_info;
     this.matches = [];
   },
@@ -247,11 +247,11 @@ var SearchResultSet = Backbone.Collection.extend({
     return file_group.id;
   },
 
-  add_match: function(match) {
+  add_match: function(id, match) {
     var path_info = match.path_info();
-    var file_group = this.get(path_info.id);
+    var file_group = this.get(id);
     if(!file_group) {
-      file_group = new FileGroup(path_info);
+      file_group = new FileGroup(id, path_info);
       this.add(file_group);
     }
     file_group.add_match(match);
@@ -330,6 +330,8 @@ var SearchState = Backbone.Model.extend({
 
   initialize: function() {
     this.search_map = {};
+    this.id_map = {};
+    this.next_filegroup_id = 1;
     this.search_results = new SearchResultSet();
     this.file_search_results = new Backbone.Collection();
     this.search_id = 0;
@@ -342,6 +344,8 @@ var SearchState = Backbone.Model.extend({
         time: null,
         why: null
     });
+    this.id_map = {};
+    this.next_filegroup_id = 1;
     this.search_results.reset();
     this.file_search_results.reset();
     for (var k in this.search_map) {
@@ -421,7 +425,13 @@ var SearchState = Backbone.Model.extend({
     this.set('displaying', search);
     var m = _.clone(match);
     m.backend = this.search_map[search].backend;
-    this.search_results.add_match(new Match(m));
+    var matchObj = new Match(m);
+    var path_id = matchObj.path_info().id;
+    if (!(path_id in this.id_map)) {
+     this.id_map[path_id] = this.next_filegroup_id;
+     this.next_filegroup_id++;
+    }
+    this.search_results.add_match(this.id_map[path_id], matchObj);
   },
   handle_file_match: function (search, file_match) {
     if (search < this.get('displaying'))


### PR DESCRIPTION
Use some extremely basic heuristics to demote results that are
apparently tests or third-party code, and promote ones that seem
especially relevant.

Though this is reasonably helpful by itself, it's very much a starting
point. A couple of obvious avenues for future improvement:
 - Use ctags definition information as an input to the scoring, and
   promote matches which are definitions.
 - Raise the backend result limit to collect and score more results,
   when we can do so quickly, then return the best $n to the user.