### PR TITLE
Make regex, repo, and context controls sticky

### DIFF
--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="/assets/3d/bootstrap.min.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/js/bootstrap-select.min.js" integrity="sha256-19J3rT3tQdidgtqqdQ3xNu++Gd7EoP/ag/0x1lHi0xY=" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/css/bootstrap-select.min.css" integrity="sha256-/us3egi2cVp0mEkVR8cnqLsuDY6BmrDuvTPUuEr1HJQ=" crossorigin="anonymous" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.1.4/js.cookie.min.js" integrity="sha256-NjbogQqosWgor0UBdCURR5dzcvAgHnfUZMcZ8RCwkk8=" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/googlecode.min.css" integrity="sha256-arq4LfC7imzesljdi/Th/9Sws1lwfF/iq5a+A7oycTg=" crossorigin="anonymous" />
     <link rel="stylesheet" href='/assets/css/codesearch.css' />
     {{if .ScriptData}}

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -19,7 +19,8 @@ module.exports = {
     jquery: 'jQuery',
     underscore: '_',
     backbone: 'Backbone',
-    'highlight.js': 'hljs'
+    'highlight.js': 'hljs',
+    'js-cookie': 'Cookies'
   },
 
   module: {


### PR DESCRIPTION
Behaviour is as follows:
 - Any time you modify one of the query controls in the UI, your modification is stored in a cookie.
 - If you navigate to the blank livegrep search page, the control settings are loaded from your cookie, falling back to defaults for any controls you've never explicitly set.
 - If you navigate to a livegrep search with a query already provided, the control settings are loaded from the URL and your preferences are ignored. This way, links to search results are stable (modulo changes to the underlying index, of course).

This doesn't make the "case" control sticky because I believe "auto" really is what the user wants 99% of the time.

Fixes #60 by addressing this portion of the issue:

> Crucially, if the last time you used that other tool you searched repository X, then the next time you go to its front page and just type a quick query, you'll get a search over repository X.