### PR TITLE
Add `test` target so `bazel test //test` works

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -26,3 +26,7 @@ cc_test(
       ]}),
     size = "small",
 )
+
+test_suite(
+    name = "test",
+)


### PR DESCRIPTION
A bare `test_suite()` target automatically includes all tests in its `BUILD` file, allowing the tests to be run without needing to type their names.