### PR TITLE
Store prefs in a long-lived cookie

### DIFF
--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -730,7 +730,7 @@ var CodesearchUI = function() {
         prefs = {};
       }
       prefs[key] = value;
-      Cookies.set('prefs', prefs);
+      Cookies.set('prefs', prefs, { expires: 36500 });
     },
     parse_query_params: function() {
       var urlParams = {};


### PR DESCRIPTION
If we don't provide an expiration, this sets a session cookie. But we'd
like preferences to be more persistant than that. js-cookie interprets
the `expires` argument as days until expiry; 100 years should be plenty.