### PR TITLE
Add reload

### DIFF
--- a/cmd/livegrep-reload/BUILD
+++ b/cmd/livegrep-reload/BUILD
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "main.go",
+    ],
+    deps = [
+        "//src/proto:go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+    data = [
+        "//src/tools:codesearch",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "livegrep-reload",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/cmd/livegrep-reload/main.go
+++ b/cmd/livegrep-reload/main.go
@@ -9,19 +9,15 @@ import (
 	"google.golang.org/grpc"
 )
 
-var (
-	flagReloadBackend = flag.String("backend", "", "Backend to reload")
-)
-
 func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
-	if len(flag.Args()) != 0 {
-		log.Fatal("Expected no arguments")
+	if len(flag.Args()) != 1 {
+		log.Fatal("You must provide a HOST:PORT to reload")
 	}
 
-	if err := reloadBackend(*flagReloadBackend); err != nil {
+	if err := reloadBackend(flag.Arg(0)); err != nil {
 		log.Fatalln("reload:", err.Error())
 	}
 }

--- a/cmd/livegrep-reload/main.go
+++ b/cmd/livegrep-reload/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	pb "github.com/livegrep/livegrep/src/proto/go_proto"
+	"google.golang.org/grpc"
+)
+
+var (
+	flagReloadBackend = flag.String("backend", "", "Backend to reload")
+)
+
+func main() {
+	flag.Parse()
+	log.SetFlags(0)
+
+	if len(flag.Args()) != 0 {
+		log.Fatal("Expected no arguments")
+	}
+
+	if err := reloadBackend(*flagReloadBackend); err != nil {
+		log.Fatalln("reload:", err.Error())
+	}
+}
+
+
+func reloadBackend(addr string) error {
+	client, err := grpc.Dial(addr, grpc.WithInsecure())
+	if err != nil {
+		return err
+	}
+
+	codesearch := pb.NewCodeSearchClient(client)
+
+	if _, err = codesearch.Reload(context.Background(), &pb.Empty{}, grpc.FailFast(false)); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This stand-alone command supports more complicated workflows than simply running `livegrep-fetch-reindex` and wanting an immediate reload when it finishes (for example, this lets you `livegrep-fetch-reindex`, then build a separate tags index, and only then reload).