### PR TITLE
Avoid double slashes in file viewer URLs

### DIFF
--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -63,6 +63,7 @@ function url(tree, version, path, lno) {
 }
 
 function internalUrl(tree, path, lno) {
+  path = path.replace(/^\/+/, '');  // Trim any leading slashes
   var url = "/view/" + tree + "/" + path;
   if (lno !== undefined) {
     url += "#L" + lno;
@@ -86,6 +87,12 @@ function externalUrl(tree, version, path, lno) {
 
   // the order of these replacements is used to minimize conflicts
   var url = repo_map[tree];
+
+  // If {path} already has a slash in front of it, trim extra leading
+  // slashes from `path` to avoid a double-slash in the URL.
+  if (url.indexOf('/{path}') !== -1)
+    path = path.replace(/^\/+/, '');
+
   url = url.replace('{lno}', lno);
   url = url.replace('{version}', shorten(version));
   url = url.replace('{name}', tree);

--- a/web/src/fileview/fileview.js
+++ b/web/src/fileview/fileview.js
@@ -170,6 +170,12 @@ function init(initData) {
     var pathInRepo = path.slice(repoName.length + 1);
 
     url = initData.repo_info.metadata['url-pattern']
+
+    // If {path} already has a slash in front of it, trim extra leading
+    // slashes from `pathInRepo` to avoid a double-slash in the URL.
+    if (url.indexOf('/{path}') !== -1)
+      pathInRepo = pathInRepo.replace(/^\/+/, '');
+
     // XXX code copied
     url = url.replace('{lno}', lno);
     url = url.replace('{version}', initData.commit);


### PR DESCRIPTION
One of our file viewing applications would return 404 on URLs with a
double slash in them, so this helps the js code avoid building them.