### PR TITLE
Bugfix: without a tags index, build no searcher

### DIFF
--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -109,7 +109,6 @@ void build_index(code_searcher *cs, const vector<std::string> &argv) {
 }
 
 void initialize_search(code_searcher *search,
-                       code_searcher *tags,
                        int argc, char **argv) {
     if (FLAGS_load_index.size() == 0) {
         if (FLAGS_dump_index.size())
@@ -132,9 +131,6 @@ void initialize_search(code_searcher *search,
         metric::dump_all();
     } else {
         search->load_index(FLAGS_load_index);
-    }
-    if (FLAGS_load_tags.size() != 0) {
-        tags->load_index(FLAGS_load_tags);
     }
     if (FLAGS_dump_index.size() && FLAGS_load_index.size())
         search->dump_index(FLAGS_dump_index);
@@ -173,15 +169,19 @@ int main(int argc, char **argv) {
 
     while (true) {
         code_searcher search;
-        code_searcher tags;
+        code_searcher *tags = NULL;
 
-        initialize_search(&search, &tags, argc, argv);
+        initialize_search(&search, argc, argv);
+        if (FLAGS_load_tags.size() != 0) {
+            tags = new code_searcher;
+            tags->load_index(FLAGS_load_tags);
+        }
 
         if (FLAGS_index_only)
             return 0;
 
         if (FLAGS_grpc.size()) {
-            listen_grpc(&search, &tags, FLAGS_grpc);
+            listen_grpc(&search, tags, FLAGS_grpc);
         }
     }
 }


### PR DESCRIPTION
Several conditionals in `grpc_server.cc` expect the tags `code_searcher`
pointer to be NULL if no tag index has been provided:

```
if (tagdata != nullptr)
response->set_has_tags(tagdata_ != nullptr);
if (tagdata_ == NULL)
```

But, alas, the initialization routine always creates a tags searcher.
Even worse, it leaves it un-finalized if no tags index was provided.
Among other things, this crashes codesearch if `tags:...` is specified
but no tags index has been provided.  And with the debut of our new
tags-first search logic, it also makes the service crash for normal
searches (!) if no tags index is available.  So here we pivot to the
behavior the server code expects: a NULL pointer if no tags index is
loaded.