### PR TITLE
Fix checks of calls returning a file descriptor

### DIFF
--- a/src/dump_load.cc
+++ b/src/dump_load.cc
@@ -30,7 +30,7 @@ public:
         hdr_() {
         assert(!stream_.fail());
         fd_ = open(path.c_str(), O_RDWR|O_APPEND);
-        assert(fd_ > 0);
+        assert(fd_ >= 0);
 
         hdr_.magic      = kIndexMagic;
         hdr_.version    = kIndexVersion;
@@ -358,7 +358,7 @@ void codesearch_index::dump() {
 
 load_allocator::load_allocator(code_searcher *cs, const string& path) {
     fd_ = open(path.c_str(), O_RDONLY);
-    assert(fd_ > 0);
+    assert(fd_ >= 0);
     struct stat st;
     assert(fstat(fd_, &st) == 0);
     map_size_ = st.st_size;


### PR DESCRIPTION
The daemon is failing on some servers because these calls return 0,
perhaps because stdin has been closed during daemonization.
These asserts should accept all valid fd numbers, including zero.