### PR TITLE
Fix HTTP[S]_PROXY by upgrading rules_go to 0.7.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,7 +71,7 @@ new_patched_http_archive(
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    commit = "e254d73bf1181101ed82791fa5d204c4c5b1b105",
+    commit = "44b3bdf7d3645cbf0cfd786c5f105d0af4cf49ca",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/server/api.go
+++ b/server/api.go
@@ -124,7 +124,7 @@ func (s *server) doSearch(ctx context.Context, backend *Backend, q *pb.Query) (*
 	defer cancel()
 
 	if id, ok := reqid.FromContext(ctx); ok {
-		ctx = metadata.NewContext(ctx, metadata.Pairs("Request-Id", string(id)))
+		ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("Request-Id", string(id)))
 	}
 
 	search, err = backend.Codesearch.Search(


### PR DESCRIPTION
This gives us https://github.com/bazelbuild/rules_go/pull/1054 which
restores to rules_go the ability to fetch Go packages with git through
an HTTP/HTTPS proxy.