### PR TITLE
Have livegrep-reload exit if server unreachable

### DIFF
--- a/cmd/livegrep-reload/main.go
+++ b/cmd/livegrep-reload/main.go
@@ -30,7 +30,7 @@ func reloadBackend(addr string) error {
 
 	codesearch := pb.NewCodeSearchClient(client)
 
-	if _, err = codesearch.Reload(context.Background(), &pb.Empty{}, grpc.FailFast(false)); err != nil {
+	if _, err = codesearch.Reload(context.Background(), &pb.Empty{}, grpc.FailFast(true)); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Otherwise, the command enters a loop trying forever to connect.