### PR TITLE
Add a "total wallclock time" calculated from livegrep

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -120,6 +120,8 @@ func (s *server) doSearch(ctx context.Context, backend *Backend, q *pb.Query) (*
 	var search *pb.CodeSearchResult
 	var err error
 
+	start := time.Now()
+
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
@@ -174,6 +176,7 @@ func (s *server) doSearch(ctx context.Context, backend *Backend, q *pb.Query) (*
 		SortTime:    search.Stats.SortTime,
 		IndexTime:   search.Stats.IndexTime,
 		AnalyzeTime: search.Stats.AnalyzeTime,
+		TotalTime:   int64(time.Since(start) / time.Millisecond),
 		ExitReason:  search.Stats.ExitReason.String(),
 	}
 	return reply, nil

--- a/server/api/types.go
+++ b/server/api/types.go
@@ -24,6 +24,7 @@ type Stats struct {
 	SortTime    int64  `json:"sort_time"`
 	IndexTime   int64  `json:"index_time"`
 	AnalyzeTime int64  `json:"analyze_time"`
+	TotalTime   int64  `json:"total_time"`
 	ExitReason  string `json:"why"`
 }
 


### PR DESCRIPTION
This allows parsing the logs to get a close approximation of the time the end-user waited for a response.