### PR TITLE
Add buttons to narrow results by file extensions

### DIFF
--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -188,8 +188,12 @@ a:hover {
     margin-top: 10px;
 }
 
-.path-results {
+.file-extensions, .path-results {
     margin-bottom: 15px;
+}
+
+.file-extensions button {
+    margin-left: 4px;
 }
 
 .file-group {


### PR DESCRIPTION
A popular request from users: buttons that automatically narrow the
current search to files matching a single extension.  The extensions
offered are all culled from the currently displayed files.

Because these buttons need to advance the search history URL to a new
state from which the user often wants to return by hitting Back, this
diff also fixes livegrep's previous problem of not preserving browser
URL history; we now create a browser history state for each search
that successfully returns and is drawn on the screen.