### PR TITLE
Free tags code_searcher before creating a new one

### DIFF
--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -183,5 +183,10 @@ int main(int argc, char **argv) {
         if (FLAGS_grpc.size()) {
             listen_grpc(&search, tags, FLAGS_grpc);
         }
+
+        if (tags) {
+            delete tags;
+            tags = NULL;
+        }
     }
 }


### PR DESCRIPTION
Otherwise, a server run with `-load_tags` will leak a memory map to its
tags index every time it reloads, potentially keeping old index files
alive instead of letting the filesystem remove them.