### PR TITLE
If a tag index is provided, search it first

### DIFF
--- a/src/codesearch.cc
+++ b/src/codesearch.cc
@@ -52,7 +52,6 @@ DEFINE_bool(index, true, "Create a suffix-array index to speed searches.");
 DEFINE_bool(compress, true, "Compress file contents linewise");
 DEFINE_bool(drop_cache, false, "Drop caches before each search");
 DEFINE_bool(search, true, "Actually do the search.");
-DEFINE_int32(max_matches, 50, "The default maximum number of results to return for a single query.");
 DEFINE_int32(timeout, 1000, "The number of milliseconds a single search may run for.");
 DEFINE_int32(threads, 4, "Number of threads to use.");
 DEFINE_int32(line_limit, 1024, "Maximum line length to index.");
@@ -112,13 +111,7 @@ const StringPiece empty_string(NULL, 0);
 
 class search_limiter {
 public:
-    search_limiter(int query_max_matches) : matches_(0), exit_reason_(kExitNone) {
-        if (FLAGS_max_matches && !query_max_matches) {
-            max_matches_ = FLAGS_max_matches;
-        } else {
-            max_matches_ = query_max_matches;
-        }
-
+    search_limiter(int query_max_matches) : matches_(0), max_matches_(query_max_matches), exit_reason_(kExitNone) {
         if (FLAGS_timeout <= 0) {
             deadline_.tv_sec = numeric_limits<time_t>::max();
         } else {

--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -127,14 +127,14 @@ struct query {
     std::string trace_id;
     int32_t max_matches;
 
-    std::unique_ptr<RE2> line_pat;
-    std::unique_ptr<RE2> file_pat;
-    std::unique_ptr<RE2> tree_pat;
-    std::unique_ptr<RE2> tags_pat;
+    std::shared_ptr<RE2> line_pat;
+    std::shared_ptr<RE2> file_pat;
+    std::shared_ptr<RE2> tree_pat;
+    std::shared_ptr<RE2> tags_pat;
     struct {
-        std::unique_ptr<RE2> file_pat;
-        std::unique_ptr<RE2> tree_pat;
-        std::unique_ptr<RE2> tags_pat;
+        std::shared_ptr<RE2> file_pat;
+        std::shared_ptr<RE2> tree_pat;
+        std::shared_ptr<RE2> tags_pat;
     } negate;
 
     bool filename_only;

--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -82,6 +82,14 @@ struct match_stats {
     timeval analyze_time;
     int matches;
     exit_reason why;
+
+    match_stats() : re2_time((struct timeval){0}),
+        git_time((struct timeval){0}),
+        sort_time((struct timeval){0}),
+        index_time((struct timeval){0}),
+        analyze_time((struct timeval){0}),
+        matches(0),
+        why(kExitNone) {}
 };
 
 struct chunk;

--- a/src/proto/go_proto
+++ b/src/proto/go_proto
@@ -1,1 +1,0 @@
-../../bazel-genfiles/src/proto

--- a/src/tools/grpc_server.cc
+++ b/src/tools/grpc_server.cc
@@ -8,6 +8,7 @@
 #include "src/tools/limits.h"
 #include "src/tools/grpc_server.h"
 
+#include "gflags/gflags.h"
 #include <json-c/json.h>
 
 #include <algorithm>
@@ -23,6 +24,8 @@ using grpc::Status;
 using grpc::StatusCode;
 
 using std::string;
+
+DEFINE_int32(max_matches, 50, "The default maximum number of matches to return for a single query.");
 
 class CodeSearchImpl final : public CodeSearch::Service {
  public:
@@ -106,12 +109,12 @@ Status CodeSearchImpl::Info(ServerContext* context, const ::InfoRequest* request
     return Status::OK;
 }
 
-Status extract_regex(std::unique_ptr<RE2> *out,
+Status extract_regex(std::shared_ptr<RE2> *out,
                      const std::string &label,
                      const std::string &input,
                      bool case_sensitive) {
     if (input.empty()) {
-        out->reset(nullptr);
+        out->reset();
         return Status::OK;
     }
 
@@ -119,7 +122,7 @@ Status extract_regex(std::unique_ptr<RE2> *out,
     default_re2_options(opts);
     opts.set_case_sensitive(case_sensitive);
 
-    std::unique_ptr<RE2> re(new RE2(input, opts));
+    std::shared_ptr<RE2> re(new RE2(input, opts));
     if (!re->ok()) {
         return Status(StatusCode::INVALID_ARGUMENT, label + ": " + re->error());
     }
@@ -127,11 +130,11 @@ Status extract_regex(std::unique_ptr<RE2> *out,
     return Status::OK;
 }
 
-Status extract_regex(std::unique_ptr<RE2> *out,
+Status extract_regex(std::shared_ptr<RE2> *out,
                      const std::string &label,
                      const std::string &input) {
     if (input.empty()) {
-        out->reset(nullptr);
+        out->reset();
         return Status::OK;
     }
     bool case_sensitive = std::any_of(input.begin(), input.end(), isupper);
@@ -159,9 +162,31 @@ Status parse_query(query *q, const ::Query* request, ::CodeSearchResult* respons
 
 class add_match {
 public:
-    add_match(CodeSearchResult* response) : response_(response) {}
+    typedef std::set<std::string> line_set;
+
+    add_match(CodeSearchResult* response)
+        : unique_lines_(NULL), response_(response) {}
+
+    add_match(line_set* unique_lines, CodeSearchResult* response)
+        : unique_lines_(unique_lines), response_(response) {}
+
+    int match_count() {
+        return response_->results_size();
+    }
 
     void operator()(const match_result *m) const {
+        if (unique_lines_ != NULL) {
+            // Avoid a duplicate if a line is returned once from the
+            // tags search then again during the main corpus search.
+            std::string key = std::string(m->file->tree->name)
+              + " " + std::string(m->file->tree->version)
+              + " " + std::string(m->file->path)
+              + " " + std::to_string(m->lno);
+            bool was_inserted = unique_lines_->insert(key).second;
+            if (!was_inserted)
+                return;
+        }
+
         auto result = response_->add_results();
         result->set_tree(m->file->tree->name);
         result->set_version(m->file->tree->version);
@@ -189,10 +214,37 @@ public:
     }
 
 private:
+    line_set* unique_lines_;
     CodeSearchResult* response_;
 };
 
-static std::string pat(const std::unique_ptr<RE2> &p) {
+static void run_tags_search(const query& main_query, code_searcher *tagdata,
+                            add_match& cb, tag_searcher* searcher,
+                            match_stats& stats) {
+    // copy of the query we can modify without altering the caller's copy
+    query q = main_query;
+
+    // the negation constraints will be checked when we transform the match
+    // (unfortunately, we can't construct a line query that checks these)
+    query constraints;
+    constraints.negate.file_pat.swap(q.negate.file_pat);
+    constraints.negate.tags_pat.swap(q.negate.tags_pat);
+
+    // modify the line pattern to match the constraints that we can handle now
+    std::string regex = tag_searcher::create_tag_line_regex_from_query(&q);
+    q.line_pat.reset(new RE2(regex, q.line_pat->options()));
+    q.file_pat.reset();
+    q.tags_pat.reset();
+
+    code_searcher::search_thread search(tagdata);
+    search.match(q,
+                 cb,
+                 cb,
+                 boost::bind(&tag_searcher::transform, searcher, &constraints, _1),
+                 &stats);
+}
+
+static std::string pat(const std::shared_ptr<RE2> &p) {
     if (p.get() == 0)
         return "";
     return p->pattern();
@@ -210,7 +262,10 @@ Status CodeSearchImpl::Search(ServerContext* context, const ::Query* request, ::
         return st;
 
     q.trace_id = current_trace_id();
+
     q.max_matches = request->max_matches();
+    if (q.max_matches <= 0 && FLAGS_max_matches)
+        q.max_matches = FLAGS_max_matches;
 
     log(q.trace_id,
         "processing query line='%s' file='%s' tree='%s' tags='%s' "
@@ -235,8 +290,58 @@ Status CodeSearchImpl::Search(ServerContext* context, const ::Query* request, ::
         return Status(StatusCode::INVALID_ARGUMENT, "Parse error");
     }
 
+    string line_pat = q.line_pat->pattern();
+
+    /* Patterns like "User.*Info" and "p\d+" might be genuine attempts
+       to match tags, so we cannot too quickly dismiss odd-looking REs
+       as justifying our skipping the phases of a tags search.  But we
+       can at least special-case a few characters that would not ever
+       appear in a pattern that matches tags.
+       TODO(brandon-rhodes): make this more sophisticated. */
+    bool might_match_tags =
+        // Characters that can't appear in an RE that matches a tag.
+        line_pat.find_first_of(" !\"#%&',-/;<=>@`") == string::npos
+        // If the user anchored the RE, then we can only run it against
+        // whole lines from the corpus, never against tags.
+        && line_pat.front() != '^'
+        && line_pat.back() != '$'
+        ;
+
     match_stats stats;
-    if (q.tags_pat == NULL) {
+    if (q.tags_pat == NULL && tagdata_ && might_match_tags) {
+        string regex;
+        int32_t max_matches = q.max_matches;  // remember original value
+
+        add_match::line_set unique_lines;
+        add_match cb(&unique_lines, response);
+
+        /* To surface the most important matches first, start with tags.
+           First pass: is the pattern an exact match for any tags? */
+        regex = "^" + line_pat + "$";
+        q.line_pat.reset(new RE2(regex, q.line_pat->options()));
+        run_tags_search(q, tagdata_, cb, tagmatch_, stats);
+
+        q.max_matches = max_matches - cb.match_count();
+        if (q.max_matches > 0) {
+
+            /* Second pass: is the pattern a prefix match for any tags? */
+            regex = "^" + line_pat + "[^\t]";
+            q.line_pat.reset(new RE2(regex, q.line_pat->options()));
+            run_tags_search(q, tagdata_, cb, tagmatch_, stats);
+
+            q.max_matches = max_matches - cb.match_count();
+            if (q.max_matches > 0) {
+
+              /* Third and final pass: full corpus search. */
+              q.line_pat.reset(new RE2(line_pat, q.line_pat->options()));
+              code_searcher::search_thread *search;
+              if (!pool_.try_pop(&search))
+                search = new code_searcher::search_thread(cs_);
+              search->match(q, cb, cb, &stats);
+              pool_.push(search);
+            }
+        }
+    } else if (q.tags_pat == NULL) {
         code_searcher::search_thread *search;
         if (!pool_.try_pop(&search))
             search = new code_searcher::search_thread(cs_);
@@ -247,26 +352,8 @@ Status CodeSearchImpl::Search(ServerContext* context, const ::Query* request, ::
         if (tagdata_ == NULL)
             return Status(StatusCode::FAILED_PRECONDITION, "No tags file available.");
 
-        code_searcher::search_thread search(tagdata_);
-
-        // the negation constraints will be checked when we transform the match
-        // (unfortunately, we can't construct a line query that checks these)
-        query constraints;
-        constraints.negate.file_pat.swap(q.negate.file_pat);
-        constraints.negate.tags_pat.swap(q.negate.tags_pat);
-
-        // modify the line pattern to match the constraints that we can handle now
-        std::string regex = tag_searcher::create_tag_line_regex_from_query(&q);
-        q.line_pat.reset(new RE2(regex, q.line_pat->options()));
-        q.file_pat.reset();
-        q.tags_pat.reset();
-
         add_match cb(response);
-        search.match(q,
-                     cb,
-                     cb,
-                     boost::bind(&tag_searcher::transform, tagmatch_, &constraints, _1),
-                     &stats);
+        run_tags_search(q, tagdata_, cb, tagmatch_, stats);
     }
 
     auto out_stats = response->mutable_stats();

--- a/src/tools/grpc_server.cc
+++ b/src/tools/grpc_server.cc
@@ -163,8 +163,7 @@ Status parse_query(query *q, const ::Query* request, ::CodeSearchResult* respons
 
 class add_match {
 public:
-    typedef std::pair<indexed_file*, int> line_set_key;
-    typedef std::set<line_set_key> line_set;
+    typedef std::set<std::pair<indexed_file*, int>> line_set;
 
     add_match(CodeSearchResult* response)
         : unique_lines_(new line_set), response_(response) {}
@@ -176,8 +175,7 @@ public:
     void operator()(const match_result *m) const {
         // Avoid a duplicate if a line is returned once from the
         // tags search then again during the main corpus search.
-        line_set_key k(m->file, m->lno);
-        bool already_inserted = ! unique_lines_->insert(k).second;
+        bool already_inserted = ! unique_lines_->insert(std::make_pair(m->file, m->lno)).second;
         if (already_inserted) {
             return;
         }

--- a/src/tools/grpc_server.cc
+++ b/src/tools/grpc_server.cc
@@ -179,7 +179,6 @@ public:
         line_set_key k(m->file, m->lno);
         bool already_inserted = ! unique_lines_->insert(k).second;
         if (already_inserted) {
-            log("DUP");
             return;
         }
 

--- a/src/tools/grpc_server.cc
+++ b/src/tools/grpc_server.cc
@@ -33,7 +33,7 @@ class CodeSearchImpl final : public CodeSearch::Service {
     virtual ~CodeSearchImpl();
 
     virtual grpc::Status Info(grpc::ServerContext* context, const ::InfoRequest* request, ::ServerInfo* response);
-    void TagsFirstSearch_(::CodeSearchResult* response, query& q, const string& line_pat, match_stats& stats);
+    void TagsFirstSearch_(::CodeSearchResult* response, query& q, match_stats& stats);
     virtual grpc::Status Search(grpc::ServerContext* context, const ::Query* request, ::CodeSearchResult* response);
     virtual grpc::Status Reload(grpc::ServerContext* context, const ::Empty* request, ::Empty* response);
 
@@ -243,7 +243,8 @@ static std::string pat(const std::shared_ptr<RE2> &p) {
     return p->pattern();
 }
 
-void CodeSearchImpl::TagsFirstSearch_(::CodeSearchResult* response, query& q, const string& line_pat, match_stats& stats) {
+void CodeSearchImpl::TagsFirstSearch_(::CodeSearchResult* response, query& q, match_stats& stats) {
+    string line_pat = q.line_pat->pattern();
     string regex;
     int32_t original_max_matches = q.max_matches;  // remember original value
 
@@ -336,7 +337,7 @@ Status CodeSearchImpl::Search(ServerContext* context, const ::Query* request, ::
 
     match_stats stats;
     if (q.tags_pat == NULL && tagdata_ && might_match_tags) {
-        CodeSearchImpl::TagsFirstSearch_(response, q, line_pat, stats);
+        CodeSearchImpl::TagsFirstSearch_(response, q, stats);
     } else if (q.tags_pat == NULL) {
         code_searcher::search_thread *search;
         if (!pool_.try_pop(&search))

--- a/test/BUILD
+++ b/test/BUILD
@@ -9,6 +9,7 @@ cc_test(
     srcs = [
         "codesearch_test.cc",
         "indexer_test.cc",
+        "tagsearch_test.cc",
         "main.cc",
     ],
     defines = select({

--- a/test/tagsearch_test.cc
+++ b/test/tagsearch_test.cc
@@ -1,0 +1,48 @@
+#include <string.h>
+#include "gtest/gtest.h"
+
+#include "re2/re2.h"
+
+#include "src/tagsearch.h"
+#include "src/lib/debug.h"
+
+TEST(tagsearch_test, TagLinesFromQuery) {
+    /* All variations on anchoring the beginning and ending of a string. */
+
+    query q = {};
+    q.line_pat.reset(new RE2("User"));
+    string r = tag_searcher::create_tag_line_regex_from_query(&q);
+    ASSERT_EQ(r, "^[^\t]*User[^\t]*\t");
+
+    q.line_pat.reset(new RE2("^User"));
+    r = tag_searcher::create_tag_line_regex_from_query(&q);
+    ASSERT_EQ(r, "^User[^\t]*\t");
+
+    q.line_pat.reset(new RE2("User$"));
+    r = tag_searcher::create_tag_line_regex_from_query(&q);
+    ASSERT_EQ(r, "^[^\t]*User\t");
+
+    q.line_pat.reset(new RE2("^User$"));
+    r = tag_searcher::create_tag_line_regex_from_query(&q);
+    ASSERT_EQ(r, "^User\t");
+
+    /* Briefer tests that each subsequent component is (a) correctly
+       interpolated, and (b) in at least one case varies how it is
+       anchored correctly. */
+
+    q.file_pat.reset(new RE2("models.py"));
+    r = tag_searcher::create_tag_line_regex_from_query(&q);
+    ASSERT_EQ(r, "^User\t[^\t]*models.py[^\t]*\t");
+
+    q.file_pat.reset(new RE2("^models.py"));
+    r = tag_searcher::create_tag_line_regex_from_query(&q);
+    ASSERT_EQ(r, "^User\tmodels.py[^\t]*\t");
+
+    q.tags_pat.reset(new RE2("c"));
+    r = tag_searcher::create_tag_line_regex_from_query(&q);
+    ASSERT_EQ(r, "^User\tmodels.py[^\t]*\t\\d+;\"\t.*c.*$");
+
+    q.file_pat.reset();
+    r = tag_searcher::create_tag_line_regex_from_query(&q);
+    ASSERT_EQ(r, "^User\t[^\t]+\t\\d+;\"\t.*c.*$");
+}

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -252,10 +252,6 @@ var FileGroup = Backbone.Model.extend({
 
 /** A set of matches that are automatically grouped by path. */
 var SearchResultSet = Backbone.Collection.extend({
-  comparator: function(file_group) {
-    return file_group.id;
-  },
-
   add_match: function(match) {
     var path_info = match.path_info();
     var file_group = this.get(path_info.id);


### PR DESCRIPTION
On the assumption that tagged lines have greater semantic weight than
other lines that match the user’s search, let’s power a search by
consulting the tags index first then falling back to the main index.