### PR TITLE
Fix an incorrect assert in filename_searcher.

### DIFF
--- a/src/codesearch.cc
+++ b/src/codesearch.cc
@@ -435,7 +435,8 @@ void filename_searcher::operator()()
         auto lb = lower_bound(left_bound, cc_->filename_positions_.end(), target);
 
         if (lb->first != target_index) {
-            assert(lb->first > target_index);
+            assert(lb == cc_->filename_positions_.end() ||
+                   lb->first > target_index);
             assert(lb != left_bound);
             lb--;
         }


### PR DESCRIPTION
This fixes backend crashes when the filename search needs to look
up a match in the last index.