### PR TITLE
Add support for walking a custom-ordered subset of filesystem paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ config.json
 vendor/re2/obj/libre2.a
 /bazel-*
 compile_commands.json
+.devbox

--- a/doc/examples/livegrep/generate_ordered_contents.sh
+++ b/doc/examples/livegrep/generate_ordered_contents.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# A simple example script for sorting paths in a directory to be indexed according to
+# their relevance. This can be used to help populate the ordered-contents field in
+# the fs_paths entry JSON.
+
+if [ -z "$1" ]
+then
+    echo 'usage: generate_ordered_contents.sh DIRECTORY'
+    exit 2
+fi
+
+cd "$1"
+
+find . -type f | awk '
+         {score = 100}
+  /test/ {score -= 10}
+  /BUILD/ {score -= 5}
+        {print score, $0}
+' | sort -k1nr | sed 's/^[-0-9]* //'

--- a/doc/examples/livegrep/index_with_ordered_contents.json
+++ b/doc/examples/livegrep/index_with_ordered_contents.json
@@ -1,0 +1,13 @@
+{
+    "name": "livegrep",
+    "fs_paths": [
+        {
+            "name": "livegrep/livegrep",
+            "path": "src/",
+            "ordered-contents": "ordered-contents.txt",
+            "metadata": {
+                "url-pattern": "https://github.com/{name}/blob/HEAD/src/{path}#L{lno}"
+            }
+        }
+    ],
+}

--- a/doc/examples/livegrep/ordered-contents.txt
+++ b/doc/examples/livegrep/ordered-contents.txt
@@ -1,0 +1,3 @@
+./codesearch.cc
+./codesearch.h
+./BUILD

--- a/src/fs_indexer.h
+++ b/src/fs_indexer.h
@@ -12,6 +12,7 @@
 
 class code_searcher;
 struct indexed_tree;
+namespace boost { namespace filesystem { class path; } }
 
 class fs_indexer {
 public:
@@ -20,13 +21,15 @@ public:
                const string& name,
                json_object *metadata = 0);
     ~fs_indexer();
-    void read_file(const std::string& path);
-    void walk(const std::string& path);
+    void walk(const boost::filesystem::path& path);
+    void walk_contents_file(const boost::filesystem::path& contents_file_path);
 protected:
     code_searcher *cs_;
     std::string repopath_;
     std::string name_;
     const indexed_tree *tree_;
+
+    void read_file(const boost::filesystem::path& path);
 };
 
 #endif

--- a/src/tools/transport.cc
+++ b/src/tools/transport.cc
@@ -80,6 +80,8 @@ json_parse_error parse_object(json_object *js, path_spec *p) {
     err = parse_object(js, "name", &p->name);
     if (!err.ok()) return err;
     err = parse_object(js, "metadata", &p->metadata);
+    if (!err.ok()) return err;
+    err = parse_object(js, "ordered-contents", &p->ordered_contents_file_path);
     return err;
 }
 

--- a/src/tools/transport.h
+++ b/src/tools/transport.h
@@ -18,6 +18,7 @@ struct json_object;
 struct path_spec {
     std::string path;
     std::string name;
+    std::string ordered_contents_file_path;
     json_object *metadata;
 
     path_spec() : metadata(NULL) {}


### PR DESCRIPTION
This lets codesearch produce an index that has been populated in a specific order to position more interesting files first, or to exclude uninteresting files entirely.

I decided to go with this approach rather than implementing ranking inside of livegrep because it gives the user the flexibility to write arbitrarily complicated filtering/ranking logic while keeping livegrep generic.