### PR TITLE
Fix relative link so it stays at directory

### DIFF
--- a/server/fileview.go
+++ b/server/fileview.go
@@ -247,7 +247,11 @@ func buildFileData(relativePath string, repo config.RepoConfig, commit string) (
 	if !strings.HasPrefix(commitHash, commit) {
 		permalink = "?commit=" + commitHash[:16]
 	} else {
-		headlink = segments[len(segments)-1].Name
+		if dirContent != nil {
+			headlink = "."
+		} else {
+			headlink = segments[len(segments)-1].Name
+		}
 	}
 
 	return &fileViewerContext{


### PR DESCRIPTION
The previous URL for the “return to HEAD” link didn’t work for
directories, since their URL ends with “/” rather than their name.