### PR TITLE
Don't pushState on initial navigation (#7)

### DIFF
--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -608,7 +608,13 @@ var ResultView = Backbone.View.extend({
           // paused at into their browser history.
           var now = Date.now();
           var two_seconds = 2000;
-          if (now - last_url_update > two_seconds) {
+          if (this.last_url === null) {
+            // If this.last_url is null, that means this is the initial
+            // navigation. We should never pushState here, otherwise the
+            // user will need to backspace twice to go back to the
+            // previous page.
+            history.replaceState(null, '', url);
+          } else if (now - last_url_update > two_seconds) {
             history.pushState(null, '', url);
           } else {
             history.replaceState(null, '', url);


### PR DESCRIPTION
When the user arrives at `/search/?q=` they are usually redirected
immediately to a more detailed URL, which shouldn’t get its own entry in
the browser history or else they will have to press “Back” twice to see
the page they were on before being sent to Livegrep.