### PR TITLE
Better help text when a selection is selected

### DIFF
--- a/web/src/fileview/fileview.js
+++ b/web/src/fileview/fileview.js
@@ -319,6 +319,15 @@ function init(initData) {
       processKeyEvent(event);
     });
 
+    $(document).mouseup(function() {
+      var selectedText = getSelectedText();
+      if(selectedText) {
+        showSelectionReminder(selectedText);
+      } else {
+        hideSelectionReminder();
+      }
+    });
+
     initializeActionButtons($('.header .header-actions'));
   }
 

--- a/web/src/fileview/fileview.js
+++ b/web/src/fileview/fileview.js
@@ -278,6 +278,16 @@ function init(initData) {
     }
   }
 
+  var showSelectionReminder = function () {
+    $('.search-without-selection').hide();
+    $('.search-with-selection').show();
+  }
+
+  var hideSelectionReminder = function () {
+    $('.search-without-selection').show();
+    $('.search-with-selection').hide();
+  }
+
   function initializePage() {
     // Initial range detection for when the page is loaded
     handleHashChange();

--- a/web/templates/fileview.html
+++ b/web/templates/fileview.html
@@ -7,7 +7,7 @@
     </nav>
     <ul class="header-actions">
       <li class="header-action">
-        <a data-action-name="search" title="Perform a new search. Keyboard shortcut: /" href="#"><span class="search-without-selection">new search</span><b class="search-with-selection" style="display:none">search for the highlighted text</b> [<span class='shortcut'>/</span>]</a>
+        <a data-action-name="search" title="Perform a new search. Keyboard shortcut: /" href="#"><span class="search-without-selection">new search</span><b class="search-with-selection" style="display:none">search for the selected text</b> [<span class='shortcut'>/</span>]</a>
       </li>,
       <li class="header-action">
         <a id="external-link" data-action-name="" title="View at {{.ExternalDomain}}. Keyboard shortcut: v" href="#">view at {{.ExternalDomain}} [<span class='shortcut'>v</span>]</a>

--- a/web/templates/fileview.html
+++ b/web/templates/fileview.html
@@ -7,7 +7,7 @@
     </nav>
     <ul class="header-actions">
       <li class="header-action">
-        <a data-action-name="search" title="Perform a new search. Keyboard shortcut: /" href="#">new search [<span class='shortcut'>/</span>]</a>
+        <a data-action-name="search" title="Perform a new search. Keyboard shortcut: /" href="#"><span class="search-without-selection">new search</span><b class="search-with-selection" style="display:none">search for the highlighted text</b> [<span class='shortcut'>/</span>]</a>
       </li>,
       <li class="header-action">
         <a id="external-link" data-action-name="" title="View at {{.ExternalDomain}}. Keyboard shortcut: v" href="#">view at {{.ExternalDomain}} [<span class='shortcut'>v</span>]</a>


### PR DESCRIPTION
When the user highlights text in the file view, update the help atop the
page to make explicit that “/” now searches for the selected text.