### PR TITLE
Create next/previous selected work shortcut

### DIFF
--- a/web/src/fileview/fileview.js
+++ b/web/src/fileview/fileview.js
@@ -248,8 +248,13 @@ function init(initData) {
         $a.focus();
         window.location = $a.attr('href');
       }
+    } else if (String.fromCharCode(event.which) == 'N' || String.fromCharCode(event.which) == 'P') {
+      var goBackwards = String.fromCharCode(event.which) === 'P';
+      var selectedText = getSelectedText();
+      if (selectedText) {
+        window.find(selectedText, false /* case sensitive */, goBackwards);
+      }
     }
-
     return true;
   }
 


### PR DESCRIPTION
Users familiar with other file viewers asked that when text is selected,
“N” and “P” move to the next and previous instance of that text.
