### PR TITLE
Fix broken `?` shortcut for help in file view

### DIFF
--- a/web/src/fileview/fileview.js
+++ b/web/src/fileview/fileview.js
@@ -319,7 +319,7 @@ function init(initData) {
       if($(event.target).is('input,textarea'))
         return;
       // Filter out key if a modifier is pressed.
-      if(event.altKey || event.ctrlKey || event.metaKey || event.shiftKey)
+      if(event.altKey || event.ctrlKey || event.metaKey)
         return;
       processKeyEvent(event);
     });


### PR DESCRIPTION
If we ignore all keystrokes when “Shift” is pressed, then users can’t
type “?” and have its shortcut fire.