### PR TITLE
Fixes following a Bazel upgrade on our end

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5,7 +5,6 @@ go_prefix("github.com/livegrep/livegrep")
 
 compilation_database(
     name = "compilation_db",
-    exec_root_marker = True,
     targets = [
         "//src/tools:codesearch",
         "//src/tools:codesearchtool",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,7 +8,7 @@ load(
 
 git_repository(
     name = "org_pubref_rules_protobuf",
-    commit = "ff3b7e7963daa7cb3b42f8936bc11eda4b960926",
+    commit = "master",
     remote = "https://github.com/pubref/rules_protobuf",
 )
 
@@ -27,21 +27,23 @@ new_patched_http_archive(
     url = "https://codeload.github.com/y-256/libdivsufsort/tar.gz/2.0.1",
 )
 
-git_repository(
+http_archive(
     name = "com_googlesource_code_re2",
-    commit = "7cf8b88e8f70f97fd4926b56aa87e7f53b2717e0",
-    remote = "https://github.com/google/re2",
+    sha256 = "c8ab833081c9766ef4e4d1e6397044ff3b20e42be109084b50d49c161f876184",
+    strip_prefix = "re2-2018-02-01",
+    url = "https://github.com/google/re2/archive/2018-02-01.tar.gz",
 )
 
-git_repository(
-    name = "gflags",
-    commit = "a69b2544d613b4bee404988710503720c487119a",
-    remote = "https://github.com/gflags/gflags",
+http_archive(
+    name = "com_github_gflags_gflags",
+    sha256 = "ae27cdbcd6a2f935baa78e4f21f675649271634c092b1be01469440495609d0e",
+    strip_prefix = "gflags-2.2.1",
+    url = "https://github.com/gflags/gflags/archive/v2.2.1.tar.gz",
 )
 
 git_repository(
     name = "com_github_nelhage_boost",
-    commit = "d6446dc9de6e43b039af07482a9361bdc6da5237",
+    commit = "for-livegrep",
     remote = "https://github.com/nelhage/rules_boost",
 )
 # local_repository(
@@ -77,7 +79,7 @@ new_patched_http_archive(
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "44b3bdf7d3645cbf0cfd786c5f105d0af4cf49ca",
+    commit = "0.7.1",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 
@@ -131,13 +133,12 @@ load("@org_dropbox_rules_node//node:defs.bzl", "node_repositories")
 
 node_repositories()
 
-new_git_repository(
+new_http_archive(
     name = "compdb",
-    build_file_content = (
-        """
-package(default_visibility = ["//visibility:public"])
-"""
-    ),
-    commit = "02c33ed2c0e86053073080fd215f44356ef5b543",
-    remote = "https://github.com/grailbio/bazel-compilation-database.git",
+    build_file_content = """
+        package(default_visibility = ["//visibility:public"])
+    """,
+    sha256 = "d4aa11e8db119ffffcf46da2468a74808c3e5aae45281e688fe1ae70e27943c7",
+    strip_prefix = "bazel-compilation-database-0.2",
+    url = "https://github.com/grailbio/bazel-compilation-database/archive/0.2.tar.gz",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,7 +8,7 @@ load(
 
 git_repository(
     name = "org_pubref_rules_protobuf",
-    commit = "master",
+    commit = "v0.8.2",
     remote = "https://github.com/pubref/rules_protobuf",
 )
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -11,6 +11,7 @@ cc_library(
         "//third_party:utf8cpp",
         "@boost//:filesystem",
         "@boost//:intrusive_ptr",
+        "@com_github_gflags_gflags//:gflags",
         "@com_github_json_c//:json",
         "@com_github_libgit2//:libgit2",
         "@com_github_sparsehash//:sparsehash",

--- a/src/lib/BUILD
+++ b/src/lib/BUILD
@@ -4,5 +4,7 @@ cc_library(
     hdrs = glob(["*.h"]),
     copts = ["-Wno-sign-compare"],
     visibility = ["//visibility:public"],
-    deps = ["@gflags"],
+    deps = [
+        "@com_github_gflags_gflags//:gflags",
+    ],
 )


### PR DESCRIPTION
We seem to be on a version of Bazel that now performs depth 1 checkouts
but that does not yet incorporate:

https://github.com/bazelbuild/bazel/commit/6496b1d1d25025f33406b1eaf9949cab126f08bd

that would presumably let us make our checkouts a bit less shallow, and
thus pin to arbitrary commits.  Instead, we must at the moment pin to
actual tags and branches on GitHub.  This diff makes the changes
necessary to pin to available versions instead of arbitrary commits;
tweaks a few things that broke during the necessary upgrades this
entailed; and where appropriate, follows the current Bazel docs in
replacing git repository fetches with HTTP archives.

The one thing I don’t like is specifying “master” for the repository
“org_pubref_rules_protobuf” — should we instead ask them to make a more
recent release?  Or fork the repository ourselves as a target?

This fixes #160 upstream.