### PR TITLE
Remove deprecated “file:” from hints on front page

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -14,7 +14,6 @@
       <code>-path:</code>
       <code>repo:</code>
       <code>-repo:</code>
-      <code>file:</code>
     </div>
   </div>
 


### PR DESCRIPTION
Our users were confused about why we advertise “file:” when the engine
also supports “path:”. They always think there must be an interesting
difference between the two. So let’s only advertise the modern one.