### PR TITLE
Fix Markdown code snippets piled at top of page

### DIFF
--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -444,7 +444,7 @@ a:hover {
     color: rgba(0, 0, 0, 1);
     text-decoration: underline;
 }
-.file-viewer .code {
+.file-viewer .code-pane {
     position: absolute;
     top: 0;
     left: 75px;

--- a/web/templates/fileview.html
+++ b/web/templates/fileview.html
@@ -54,7 +54,7 @@
       {{end}}
       {{with .FileContent}}
       <div class="file-content">
-        <code id="source-code" class="code language-{{.Language}}">{{.Content}}</code>
+        <code id="source-code" class="code-pane language-{{.Language}}">{{.Content}}</code>
         <!--
         NOTE: The reason the line number links are after the code block above is because
         they take a significant amount of time to render for large files. If we keep


### PR DESCRIPTION
A very generic CSS class name (“code”) was used in the file viewer to
position the pane of source code absolutely at the top of the page.
Alas, “code” is also used as a CSS class when prism.js is highlighting a
code snippet inside of Markdown.  So let’s fix the collision.