### PR TITLE
Remove duplicate <link> to “codesearch.css”

### DIFF
--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -13,7 +13,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/js/bootstrap-select.min.js" integrity="sha256-19J3rT3tQdidgtqqdQ3xNu++Gd7EoP/ag/0x1lHi0xY=" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/css/bootstrap-select.min.css" integrity="sha256-/us3egi2cVp0mEkVR8cnqLsuDY6BmrDuvTPUuEr1HJQ=" crossorigin="anonymous" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.1.4/js.cookie.min.js" integrity="sha256-NjbogQqosWgor0UBdCURR5dzcvAgHnfUZMcZ8RCwkk8=" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href='/assets/css/codesearch.css' />
     {{if .ScriptData}}
     <script>
       window.scriptData = {{.ScriptData}};


### PR DESCRIPTION
There’s another <link> to it 9 lines above this, and the other one
is nicer: it includes the asset hash.