### PR TITLE
Add “ScriptNonce” that adds attribute to scripts

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -96,7 +96,7 @@ func (s *server) ServeSearch(ctx context.Context, w http.ResponseWriter, r *http
 	}
 	s.renderPage(w, &page{
 		Title:         "code search",
-                ScriptNonce:   "",
+		ScriptNonce:   "",
 		ScriptName:    "codesearch",
 		ScriptData:    script_data,
 		IncludeHeader: true,
@@ -141,7 +141,7 @@ func (s *server) ServeFile(ctx context.Context, w http.ResponseWriter, r *http.R
 	}
 	s.renderPage(w, &page{
 		Title:         data.PathSegments[len(data.PathSegments)-1].Name,
-                ScriptNonce:   "",
+		ScriptNonce:   "",
 		ScriptName:    "fileview",
 		ScriptData:    script_data,
 		IncludeHeader: false,

--- a/server/server.go
+++ b/server/server.go
@@ -96,6 +96,7 @@ func (s *server) ServeSearch(ctx context.Context, w http.ResponseWriter, r *http
 	}
 	s.renderPage(w, &page{
 		Title:         "code search",
+                ScriptNonce:   "",
 		ScriptName:    "codesearch",
 		ScriptData:    script_data,
 		IncludeHeader: true,
@@ -140,6 +141,7 @@ func (s *server) ServeFile(ctx context.Context, w http.ResponseWriter, r *http.R
 	}
 	s.renderPage(w, &page{
 		Title:         data.PathSegments[len(data.PathSegments)-1].Name,
+                ScriptNonce:   "",
 		ScriptName:    "fileview",
 		ScriptData:    script_data,
 		IncludeHeader: false,

--- a/server/templates.go
+++ b/server/templates.go
@@ -12,7 +12,7 @@ import (
 
 type page struct {
 	Title         string
-        ScriptNonce   string
+	ScriptNonce   string
 	ScriptName    string
 	ScriptData    interface{}
 	IncludeHeader bool

--- a/server/templates.go
+++ b/server/templates.go
@@ -12,6 +12,7 @@ import (
 
 type page struct {
 	Title         string
+        ScriptNonce   string
 	ScriptName    string
 	ScriptData    interface{}
 	IncludeHeader bool

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -14,12 +14,12 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/css/bootstrap-select.min.css" integrity="sha256-/us3egi2cVp0mEkVR8cnqLsuDY6BmrDuvTPUuEr1HJQ=" crossorigin="anonymous" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.1.4/js.cookie.min.js" integrity="sha256-NjbogQqosWgor0UBdCURR5dzcvAgHnfUZMcZ8RCwkk8=" crossorigin="anonymous"></script>
     {{if .ScriptData}}
-    <script>
+    <script{{if .ScriptNonce}} nonce="{{.ScriptNonce}}"{{end}}>
       window.scriptData = {{.ScriptData}};
     </script>
     {{end}}
     {{if .ScriptName}}
-    <script>
+    <script{{if .ScriptNonce}} nonce="{{.ScriptNonce}}"{{end}}>
       window.page = {{.ScriptName}};
     </script>
     {{end}}


### PR DESCRIPTION
Here at Dropbox we’ll be using a nonce to protect each bare `<script>`
tag, and this code makes it easy for third parties to add nonces without
editing the code in too many places.