### PR TITLE
Fix nonces by adding them to all script, link tags

### DIFF
--- a/server/templates/templates.go
+++ b/server/templates/templates.go
@@ -4,27 +4,33 @@ import (
 	"bufio"
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 	"html/template"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
-func linkTag(rel string, s string, m map[string]string) template.HTML {
+func linkTag(nonce template.HTMLAttr, rel string, s string, m map[string]string) template.HTML {
 	hash := m[strings.TrimPrefix(s, "/")]
 	href := s + "?v=" + hash
 	hashBytes, _ := hex.DecodeString(hash)
 	integrity := "sha256-" + base64.StdEncoding.EncodeToString(hashBytes)
-	return template.HTML(`<link rel="` + rel + `" href="` + href + `" integrity="` + integrity + `" />`)
+	return template.HTML(fmt.Sprintf(
+		`<link%s rel="%s" href="%s" integrity="%s" />`,
+		nonce, rel, href, integrity,
+	))
 }
 
-func scriptTag(s string, m map[string]string) template.HTML {
+func scriptTag(nonce template.HTMLAttr, s string, m map[string]string) template.HTML {
 	hash := m[strings.TrimPrefix(s, "/")]
 	href := s + "?v=" + hash
 	hashBytes, _ := hex.DecodeString(hash)
 	integrity := "sha256-" + base64.StdEncoding.EncodeToString(hashBytes)
-	return template.HTML(`<script src="` + href + `" integrity="` + integrity + `"></script>`)
-
+	return template.HTML(fmt.Sprintf(
+		`<script%s src="%s" integrity="%s"></script>`,
+		nonce, href, integrity,
+	))
 }
 
 func getFuncs() map[string]interface{} {

--- a/web/templates/common/layout.html
+++ b/web/templates/common/layout.html
@@ -4,36 +4,36 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>{{.Title}}</title>
-    {{linkTag "shortcut icon" "/assets/img/favicon.ico" .AssetHashes}}
-    {{linkTag "stylesheet" "/assets/3d/bootstrap.min.css" .AssetHashes}}
-    {{linkTag "stylesheet" "/assets/css/codesearch.css" .AssetHashes}}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.3.1/underscore-min.js" integrity="sha256-Qtj60TvCj8cmd1GW7Jq5U/6/m94XXFhFEoNhyVP6F/Q=" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/0.9.2/backbone-min.js" integrity="sha256-tQjdUhE0MTzHcOzRUuotgnMrURWIamfdqwv1QWB57uk=" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/js/bootstrap-select.min.js" integrity="sha256-19J3rT3tQdidgtqqdQ3xNu++Gd7EoP/ag/0x1lHi0xY=" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/css/bootstrap-select.min.css" integrity="sha256-/us3egi2cVp0mEkVR8cnqLsuDY6BmrDuvTPUuEr1HJQ=" crossorigin="anonymous" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.1.4/js.cookie.min.js" integrity="sha256-NjbogQqosWgor0UBdCURR5dzcvAgHnfUZMcZ8RCwkk8=" crossorigin="anonymous"></script>
+    {{linkTag .Nonce "shortcut icon" "/assets/img/favicon.ico" .AssetHashes}}
+    {{linkTag .Nonce "stylesheet" "/assets/3d/bootstrap.min.css" .AssetHashes}}
+    {{linkTag .Nonce "stylesheet" "/assets/css/codesearch.css" .AssetHashes}}
+    <script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
+    <script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.3.1/underscore-min.js" integrity="sha256-Qtj60TvCj8cmd1GW7Jq5U/6/m94XXFhFEoNhyVP6F/Q=" crossorigin="anonymous"></script>
+    <script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/0.9.2/backbone-min.js" integrity="sha256-tQjdUhE0MTzHcOzRUuotgnMrURWIamfdqwv1QWB57uk=" crossorigin="anonymous"></script>
+    <script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+    <script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/js/bootstrap-select.min.js" integrity="sha256-19J3rT3tQdidgtqqdQ3xNu++Gd7EoP/ag/0x1lHi0xY=" crossorigin="anonymous"></script>
+    <link{{.Nonce}} rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/css/bootstrap-select.min.css" integrity="sha256-/us3egi2cVp0mEkVR8cnqLsuDY6BmrDuvTPUuEr1HJQ=" crossorigin="anonymous" />
+    <script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.1.4/js.cookie.min.js" integrity="sha256-NjbogQqosWgor0UBdCURR5dzcvAgHnfUZMcZ8RCwkk8=" crossorigin="anonymous"></script>
     {{if .ScriptData}}
-    <script{{if .ScriptNonce}} nonce="{{.ScriptNonce}}"{{end}}>
+    <script{{.Nonce}}>
       window.scriptData = {{.ScriptData}};
     </script>
     {{end}}
     {{if .ScriptName}}
-    <script{{if .ScriptNonce}} nonce="{{.ScriptNonce}}"{{end}}>
+    <script{{.Nonce}}>
       window.page = {{.ScriptName}};
     </script>
     {{end}}
-    {{scriptTag "/assets/js/bundle.js" .AssetHashes}}
+    {{scriptTag .Nonce "/assets/js/bundle.js" .AssetHashes}}
     {{if .Config.Sentry.URI}}
-    <script src="//cdn.ravenjs.com/1.1.15/jquery,native/raven.min.js"></script>
-    <script>
+    <script{{.Nonce}} src="//cdn.ravenjs.com/1.1.15/jquery,native/raven.min.js"></script>
+    <script{{.Nonce}}>
       Raven.config({{.Config.Sentry.URI}}, {}).install();
     </script>
     {{end}}
 
     {{if .Config.GoogleAnalyticsId}}
-    <script type="text/javascript">
+    <script{{.Nonce}} type="text/javascript">
 
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -45,7 +45,7 @@
 
     </script>
     {{end}}
-    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Stripe Code Search" />
+    <link{{.Nonce}} rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Stripe Code Search" />
   </head>
   <body>
     {{if .IncludeHeader}}

--- a/web/templates/fileview.html
+++ b/web/templates/fileview.html
@@ -94,12 +94,12 @@
     </div>
   </section>
 </section>
+{{end}}
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/prism.min.js" integrity="sha384-55dGHwJ+p8K+4zJGgJR7q7Fl9FuG++oKmlhKuS+dWjEMj6rBCp7AFYw55b0E5/K8" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/plugins/autoloader/prism-autoloader.min.js" integrity="sha384-S+UYfywCk42UjE2CVTgW2zT3c/X5Uw25LTU93Pn5HmyD5D31yHRu6I5VadHu3Qf5" crossorigin="anonymous"></script>
-<script>
+<script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/prism.min.js" integrity="sha384-55dGHwJ+p8K+4zJGgJR7q7Fl9FuG++oKmlhKuS+dWjEMj6rBCp7AFYw55b0E5/K8" crossorigin="anonymous"></script>
+<script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/plugins/autoloader/prism-autoloader.min.js" integrity="sha384-S+UYfywCk42UjE2CVTgW2zT3c/X5Uw25LTU93Pn5HmyD5D31yHRu6I5VadHu3Qf5" crossorigin="anonymous"></script>
+<script{{.Nonce}}>
   Prism.plugins.autoloader.languages_path =
   'https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/components/';
 </script>
-{{end}}
 {{end}}


### PR DESCRIPTION
It turns out?  Our CSP wants nonces on *every* script and link tag, not
just inline scripts.  Thanks to the recent template simplification, it’s
now easy to use the Nonce both up in the main “layout.html” template and
also down in specific templates like “fileview.html”.

This also simplifies the code by precomputing the full text of the HTML
attribute, so that the templates needn’t be festooned with “if” statements.