### PR TITLE
Display option to view in Livegrep viewer when external repository is configured

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -69,4 +69,7 @@ type RepoConfig struct {
 	Name      string            `json:"name"`
 	Revisions []string          `json:"revisions"`
 	Metadata  map[string]string `json:"metadata"`
+
+	// Use external link as default in search view.
+	LinkExternal bool `json:"link_external"`
 }

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -64,7 +64,7 @@ function shorten(ref) {
 }
 
 function url(tree, version, path, lno) {
-  if (tree in CodesearchUI.internalViewRepos) {
+  if (tree in CodesearchUI.internalViewRepos && !CodesearchUI.internalViewRepos[tree].link_external) {
     return internalUrl(tree, path, lno);
   } else {
     return externalUrl(tree, version, path, lno);
@@ -197,6 +197,10 @@ var Match = Backbone.Model.extend({
     }
     return url(this.get('tree'), this.get('version'), this.get('path'), lno);
   },
+
+  internalUrl: function(lno) {
+      return internalUrl(this.get('tree'), this.get('path'), lno);
+  },
 });
 
 /** A set of Matches at a single path. */
@@ -302,6 +306,10 @@ var FileMatch = Backbone.Model.extend({
   url: function() {
     return url(this.get('tree'), this.get('version'), this.get('path'));
   },
+
+  internalUrl: function() {
+      return internalUrl(this.get('tree'), this.get('path'));
+  },
 });
 
 var FileMatchView = Backbone.View.extend({
@@ -326,6 +334,18 @@ var FileMatchView = Backbone.View.extend({
     el.empty();
     el.addClass('filename-match');
     el.append(h.a({cls: 'label header result-path', href: this.model.url()}, repoLabel));
+
+    var tree = path_info.tree;
+    if (tree in CodesearchUI.internalViewRepos && CodesearchUI.internalViewRepos[tree].link_external) {
+        el.append(h.span({}, [' - ']));
+        el.append(
+            h.span({}, [h.a({
+                cls: 'label header result-path',
+                href: this.model.internalUrl()
+            }, [" View in livegrep"])])
+        );
+    }
+
     return this;
   }
 });
@@ -484,8 +504,17 @@ var FileGroupView = Backbone.View.extend({
   render: function() {
     var matches = this.model.matches;
     var el = this.$el;
+    var tree = this.model.path_info.tree;
     el.empty();
-    el.append(this.render_header(this.model.path_info.tree, this.model.path_info.version, this.model.path_info.path));
+    el.append(this.render_header(tree, this.model.path_info.version, this.model.path_info.path));
+    if (tree in CodesearchUI.internalViewRepos && CodesearchUI.internalViewRepos[tree].link_external) {
+        el.append(
+            h.span({style: "float:right;"}, [h.a({
+                cls: 'label header result-path',
+                href: this.model.matches[0].internalUrl()
+            }, ["View in livegrep"])])
+        );
+    }
     matches.forEach(function(match) {
       el.append(
         new MatchView({model:match}).render().el


### PR DESCRIPTION
Currently Livegrep is configured to either link to an external file viewer (e.g GitHub) or use the internal file viewer.

Users may want to choose between the two, e.g GitHub to browse across revisions, or Livegrep to use the LSP integration so this PR adds a configuration option to link to the internal viewer in addition to the internal viewer.

When enabled it looks like the following.

<img width="1648" alt="screen shot 2018-07-27 at 10 08 02 am" src="https://user-images.githubusercontent.com/37812933/43335951-fc205d80-9184-11e8-88b3-44d3d428d50a.png">
