### PR TITLE
 Fix internal file viewer for repository names containing '/' character

### DIFF
--- a/server/BUILD
+++ b/server/BUILD
@@ -36,7 +36,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["query_test.go"],
+    srcs = ["query_test.go", "server_test.go"],
     library = ":go_default_library",
     deps = ["//src/proto:go_proto"],
 )

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"regexp"
+	"testing"
+)
+
+func assertRepoPath(t *testing.T,
+	repoRegex *regexp.Regexp,
+	url string,
+	expectedRepo string,
+	expectedPath string,
+	expectedErr error) {
+	actualRepo, actualPath, err := getRepoPathFromURL(repoRegex, url)
+	if err != expectedErr {
+		t.Errorf("error expectation mismatch when parsing url, got %v, expected %v", err.Error(), expectedErr)
+	}
+
+	if actualRepo != expectedRepo {
+		t.Errorf("repo expectation mismatch when parsing url, got %v, expected %v", actualRepo, expectedRepo)
+	}
+
+	if actualPath != expectedPath {
+		t.Errorf("repo expectation mismatch when parsing url, got %v, expected %v", actualPath, expectedPath)
+	}
+}
+
+func TestRepoRegexParsing(t *testing.T) {
+	repoNames := []string{"test-repo", "test-org/test-repo", "test-repo-2", "foobar"}
+
+	repoRegex, err := buildRepoRegex(repoNames)
+	if err != nil {
+		t.Errorf("unexpected error building repo regex (%v)", err.Error())
+	}
+
+	assertRepoPath(t, repoRegex, "/view/test-repo/path/to/foobar.css", "test-repo", "path/to/foobar.css", nil)
+	assertRepoPath(t, repoRegex, "/view/test-org/test-repo/path/to/foobar.css", "test-org/test-repo", "path/to/foobar.css", nil)
+	assertRepoPath(t, repoRegex, "/view/test-repo-2/path/to/foobar.css", "test-repo-2", "path/to/foobar.css", nil)
+	assertRepoPath(t, repoRegex, "/view/foobar/path/to/foobar.css", "foobar", "path/to/foobar.css", nil)
+	assertRepoPath(t, repoRegex, "/view/not-exist/path/to/foobar.css", "", "", serveUrlParseError)
+	assertRepoPath(t, repoRegex, "/not/even/a/url/not-exist/path/to/foobar.css", "", "", serveUrlParseError)
+}


### PR DESCRIPTION
At the moment we can't use the internal file viewer because it has the assumption that repository names cannot contain forward slashes.

This isn't true of GitHub repositories ("livegrep/livegrep"), so to make the internal viewer work for repositories containing slashes it seems like the easiest thing to do is replace the route parsing logic with our own.

We do this by building a regular expression which can match on any of the configured repositories followed by a `/` and the path. I haven't thought too much about the performance implications of the regular expression with a sufficiently large number of repositories, so open to doing the matching differently.