### PR TITLE
Prevent “|” from breaking tags-based searches

### DIFF
--- a/test/tagsearch_test.cc
+++ b/test/tagsearch_test.cc
@@ -12,19 +12,19 @@ TEST(tagsearch_test, TagLinesFromQuery) {
     query q = {};
     q.line_pat.reset(new RE2("User"));
     string r = tag_searcher::create_tag_line_regex_from_query(&q);
-    ASSERT_EQ(r, "^[^\t]*User[^\t]*\t");
+    ASSERT_EQ(r, "^[^\t]*(User)[^\t]*\t");
 
     q.line_pat.reset(new RE2("^User"));
     r = tag_searcher::create_tag_line_regex_from_query(&q);
-    ASSERT_EQ(r, "^User[^\t]*\t");
+    ASSERT_EQ(r, "^(User)[^\t]*\t");
 
     q.line_pat.reset(new RE2("User$"));
     r = tag_searcher::create_tag_line_regex_from_query(&q);
-    ASSERT_EQ(r, "^[^\t]*User\t");
+    ASSERT_EQ(r, "^[^\t]*(User)\t");
 
     q.line_pat.reset(new RE2("^User$"));
     r = tag_searcher::create_tag_line_regex_from_query(&q);
-    ASSERT_EQ(r, "^User\t");
+    ASSERT_EQ(r, "^(User)\t");
 
     /* Briefer tests that each subsequent component is (a) correctly
        interpolated, and (b) in at least one case varies how it is
@@ -32,17 +32,17 @@ TEST(tagsearch_test, TagLinesFromQuery) {
 
     q.file_pat.reset(new RE2("models.py"));
     r = tag_searcher::create_tag_line_regex_from_query(&q);
-    ASSERT_EQ(r, "^User\t[^\t]*models.py[^\t]*\t");
+    ASSERT_EQ(r, "^(User)\t[^\t]*(models.py)[^\t]*\t");
 
     q.file_pat.reset(new RE2("^models.py"));
     r = tag_searcher::create_tag_line_regex_from_query(&q);
-    ASSERT_EQ(r, "^User\tmodels.py[^\t]*\t");
+    ASSERT_EQ(r, "^(User)\t(models.py)[^\t]*\t");
 
     q.tags_pat.reset(new RE2("c"));
     r = tag_searcher::create_tag_line_regex_from_query(&q);
-    ASSERT_EQ(r, "^User\tmodels.py[^\t]*\t\\d+;\"\t.*c.*$");
+    ASSERT_EQ(r, "^(User)\t(models.py)[^\t]*\t\\d+;\"\t.*(c).*$");
 
     q.file_pat.reset();
     r = tag_searcher::create_tag_line_regex_from_query(&q);
-    ASSERT_EQ(r, "^User\t[^\t]+\t\\d+;\"\t.*c.*$");
+    ASSERT_EQ(r, "^(User)\t[^\t]+\t\\d+;\"\t.*(c).*$");
 }


### PR DESCRIPTION
An interior “|” inside either the main pattern or the file path pattern
would cause the tags-based search to match many lines it should not,
since the subordinate patterns were being combined into a single pattern
without parens around the subordinate patterns.