### PR TITLE
Add configurable links to files and lines

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -74,7 +74,7 @@ type RepoConfig struct {
 }
 
 type LinkConfig struct {
-	Label                string `json:"label"`
-	UrlPattern           string `json:"url-pattern"`
-	WhitelistRepoPattern string `json:"whitelist-repo-pattern"`
+	Label            string `json:"label"`
+	UrlTemplate      string `json:"url_template"`
+	WhitelistPattern string `json:"whitelist_pattern"`
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -57,6 +57,8 @@ type Config struct {
 	IndexConfig IndexConfig `json:"index_config"`
 
 	DefaultSearchRepos []string `json:"default_search_repos"`
+
+	LinkConfigs []LinkConfig `json:"file_links"`
 }
 
 type IndexConfig struct {
@@ -69,4 +71,10 @@ type RepoConfig struct {
 	Name      string            `json:"name"`
 	Revisions []string          `json:"revisions"`
 	Metadata  map[string]string `json:"metadata"`
+}
+
+type LinkConfig struct {
+	Label                string `json:"label"`
+	UrlPattern           string `json:"url-pattern"`
+	WhitelistRepoPattern string `json:"whitelist-repo-pattern"`
 }

--- a/server/server.go
+++ b/server/server.go
@@ -98,21 +98,12 @@ func (s *server) ServeSearch(ctx context.Context, w http.ResponseWriter, r *http
 		bk.I.Unlock()
 	}
 
-	link_configs := make([]map[string]string, len(s.config.LinkConfigs))
-	for idx, link_config := range s.config.LinkConfigs {
-		link_configs[idx] = map[string]string{
-			"label":                link_config.Label,
-			"url":                  link_config.UrlPattern,
-			"whitelistRepoPattern": link_config.WhitelistRepoPattern,
-		}
-	}
-
 	script_data := &struct {
 		RepoUrls           map[string]map[string]string `json:"repo_urls"`
 		InternalViewRepos  map[string]config.RepoConfig `json:"internal_view_repos"`
 		DefaultSearchRepos []string                     `json:"default_search_repos"`
-		LinkConfigs        []map[string]string          `json:"link_configs"`
-	}{urls, s.repos, s.config.DefaultSearchRepos, link_configs}
+		LinkConfigs        []config.LinkConfig          `json:"link_configs"`
+	}{urls, s.repos, s.config.DefaultSearchRepos, s.config.LinkConfigs}
 
 	s.renderPage(ctx, w, r, "index.html", &page{
 		Title:         "code search",

--- a/server/server.go
+++ b/server/server.go
@@ -98,11 +98,21 @@ func (s *server) ServeSearch(ctx context.Context, w http.ResponseWriter, r *http
 		bk.I.Unlock()
 	}
 
+	link_configs := make([]map[string]string, len(s.config.LinkConfigs))
+	for idx, link_config := range s.config.LinkConfigs {
+		link_configs[idx] = map[string]string{
+			"label":                link_config.Label,
+			"url":                  link_config.UrlPattern,
+			"whitelistRepoPattern": link_config.WhitelistRepoPattern,
+		}
+	}
+
 	script_data := &struct {
 		RepoUrls           map[string]map[string]string `json:"repo_urls"`
 		InternalViewRepos  map[string]config.RepoConfig `json:"internal_view_repos"`
 		DefaultSearchRepos []string                     `json:"default_search_repos"`
-	}{urls, s.repos, s.config.DefaultSearchRepos}
+		LinkConfigs        []map[string]string          `json:"link_configs"`
+	}{urls, s.repos, s.config.DefaultSearchRepos, link_configs}
 
 	s.renderPage(ctx, w, r, "index.html", &page{
 		Title:         "code search",

--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -205,8 +205,15 @@ a:hover {
 }
 
 .file-group .header {
-    display: inline-block;
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
     padding: 3px 5px;
+}
+
+.file-action-link-separator {
+    padding-left: 3px;
+    padding-right: 3px;
 }
 
 .result-path {
@@ -226,15 +233,12 @@ a:hover {
 
 .match {
     display: block;
-    border: solid 0 rgba(0, 0, 0, 0.15);
-    border-top-width: 1px;
-    margin-top: 5px;
     background-color: #fff;
 }
 
-.match:first-of-type {
-    border-top-width: 0;
-    margin-top: 0px;
+.match + .match {
+    border: solid 1px rgba(0, 0, 0, 0.15);
+    margin-top: 5px;
 }
 
 .match.clip-before {
@@ -252,7 +256,7 @@ a:hover {
 
 .match .contents {
     display: grid;
-    grid-template-columns: 4em auto;
+    grid-template-columns: 4em auto auto;
     white-space: pre-wrap;
     font-family: "Menlo", "Consolas", "Monaco", monospace;
     font-size: 12px;
@@ -303,6 +307,19 @@ a:hover {
 
 .matchlno {
     font-weight: bold;
+}
+
+.matchlinks {
+    opacity: 0.3;
+    text-align: right;
+}
+
+.match:hover {
+    background-color: #f5f5f5;
+}
+
+.match:hover .matchlinks {
+    opacity: 1.0;
 }
 
 .matchstr {

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -114,7 +114,8 @@ function externalUrl(url, tree, version, path, lno) {
 
 function renderLinkConfigs(linkConfigs, tree, version, path, lno) {
   linkConfigs = linkConfigs.filter(function(linkConfig) {
-    return !linkConfig.whitelistRepoPattern || linkConfig.whitelistRepoPattern.test(tree);
+    return !linkConfig.whitelist_pattern ||
+      linkConfig.whitelist_pattern.test(tree + ':' + version + ':' + path);
   });
 
   var links = linkConfigs.map(
@@ -123,7 +124,7 @@ function renderLinkConfigs(linkConfigs, tree, version, path, lno) {
         {
           cls: "file-action-link",
           href: externalUrl(
-            linkConfig.url,
+            linkConfig.url_template,
             tree,
             version,
             path,
@@ -197,7 +198,7 @@ var MatchView = Backbone.View.extend({
 
     var links = renderLinkConfigs(
       CodesearchUI.linkConfigs.filter(function(linkConfig) {
-        return linkConfig.url.includes('{lno}');
+        return linkConfig.url_template.includes('{lno}');
       }),
       this.model.get('tree'),
       this.model.get('version'),
@@ -985,8 +986,8 @@ CodesearchUI.repo_urls = initData.repo_urls;
 CodesearchUI.internalViewRepos = initData.internal_view_repos;
 CodesearchUI.defaultSearchRepos = initData.default_search_repos;
 CodesearchUI.linkConfigs = (initData.link_configs || []).map(function(link_config) {
-  if (link_config.whitelistRepoPattern) {
-    link_config.whitelistRepoPattern = new RegExp(link_config.whitelistRepoPattern);
+  if (link_config.whitelist_pattern) {
+    link_config.whitelist_pattern = new RegExp(link_config.whitelist_pattern);
   }
   return link_config;
 });

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -67,7 +67,7 @@ function url(tree, version, path, lno) {
   if (tree in CodesearchUI.internalViewRepos) {
     return internalUrl(tree, path, lno);
   } else {
-    return externalUrl(tree, version, path, lno);
+    return externalRepoUrl(tree, version, path, lno);
   }
 }
 
@@ -80,7 +80,7 @@ function internalUrl(tree, path, lno) {
   return url;
 }
 
-function externalUrl(tree, version, path, lno) {
+function externalRepoUrl(tree, version, path, lno) {
   var backend = Codesearch.in_flight.backend;
   var repo_map = CodesearchUI.repo_urls[backend];
   if (!repo_map) {
@@ -89,24 +89,59 @@ function externalUrl(tree, version, path, lno) {
   if (!repo_map[tree]) {
     return null;
   }
+  return externalUrl(repo_map[tree], tree, version, path, lno);
+}
 
+function externalUrl(url, tree, version, path, lno) {
   if (lno === undefined) {
       lno = 1;
   }
 
-  // the order of these replacements is used to minimize conflicts
-  var url = repo_map[tree];
-
   // If {path} already has a slash in front of it, trim extra leading
   // slashes from `path` to avoid a double-slash in the URL.
-  if (url.indexOf('/{path}') !== -1)
+  if (url.indexOf('/{path}') !== -1) {
     path = path.replace(/^\/+/, '');
+  }
 
-  url = url.replace('{lno}', lno);
-  url = url.replace('{version}', shorten(version));
-  url = url.replace('{name}', tree);
-  url = url.replace('{path}', path);
+  // the order of these replacements is used to minimize conflicts
+  url = url.replace(/{lno}/g, lno);
+  url = url.replace(/{version}/g, shorten(version));
+  url = url.replace(/{name}/g, tree);
+  url = url.replace(/{basename}/g, tree.split("/")[1]); // E.g. "foo" in "username/foo"
+  url = url.replace(/{path}/g, path);
   return url;
+}
+
+function renderLinkConfigs(linkConfigs, tree, version, path, lno) {
+  linkConfigs = linkConfigs.filter(function(linkConfig) {
+    return !linkConfig.whitelistRepoPattern || linkConfig.whitelistRepoPattern.test(tree);
+  });
+
+  var links = linkConfigs.map(
+    function(linkConfig) {
+      return h.a(
+        {
+          cls: "file-action-link",
+          href: externalUrl(
+            linkConfig.url,
+            tree,
+            version,
+            path,
+            lno
+          ),
+        },
+        [linkConfig.label]
+      );
+    }
+  );
+  var out = [];
+  for (var i = 0; i < links.length; i++) {
+    if (i > 0) {
+      out.push(h.span({cls: "file-action-link-separator",}, ["\u00B7"]));
+    }
+    out.push(links[i]);
+  }
+  return out;
 }
 
 var MatchView = Backbone.View.extend({
@@ -138,14 +173,16 @@ var MatchView = Backbone.View.extend({
     for (i = 0; i < lines_to_display_before; i ++) {
       ctx_before.unshift(
         this._renderLno(lno - i - 1, false),
-        h.span([this.model.get('context_before')[i]])
+        h.span([this.model.get('context_before')[i]]),
+        h.span({}, [])
       );
     }
     var lines_to_display_after = Math.max(0, ctxAfter.length - (clip_after || 0));
     for (i = 0; i < lines_to_display_after; i ++) {
       ctx_after.push(
         this._renderLno(lno + i + 1, false),
-        h.span([this.model.get('context_after')[i]])
+        h.span([this.model.get('context_after')[i]]),
+        h.span({}, [])
       );
     }
     var line = this.model.get('line');
@@ -158,12 +195,23 @@ var MatchView = Backbone.View.extend({
     if(clip_before !== undefined) classes.push('clip-before');
     if(clip_after !== undefined) classes.push('clip-after');
 
+    var links = renderLinkConfigs(
+      CodesearchUI.linkConfigs.filter(function(linkConfig) {
+        return linkConfig.url.includes('{lno}');
+      }),
+      this.model.get('tree'),
+      this.model.get('version'),
+      this.model.get('path'),
+      lno
+    );
+
     var matchElement = h.div({cls: classes.join(' ')}, [
       h.div({cls: 'contents'}, [].concat(
         ctx_before,
         [
             this._renderLno(lno, true),
-            h.span({cls: 'matchline'}, [pieces[0], h.span({cls: 'matchstr'}, [pieces[1]]), pieces[2]])
+            h.span({cls: 'matchline'}, [pieces[0], h.span({cls: 'matchstr'}, [pieces[1]]), pieces[2]]),
+            h.span({cls: 'matchlinks'}, links)
         ],
         ctx_after
       ))
@@ -472,13 +520,24 @@ var FileGroupView = Backbone.View.extend({
       dirname = '';
     }
 
-    var repoLabel = [
-      h.span({cls: "repo"}, [tree, ':']),
-      h.span({cls: "version"}, [shorten(version), ':']),
-      dirname,
-      h.span({cls: "filename"}, [basename])
+    var first_match = this.model.matches[0];
+
+    var headerChildren = [
+      h.a(
+        {cls: 'result-path', href: first_match.url()},
+        [
+          h.span({cls: "repo"}, [tree, ':']),
+          h.span({cls: "version"}, [shorten(version), ':']),
+          dirname,
+          h.span({cls: "filename"}, [basename]),
+        ]
+      ),
+      h.div(
+        {cls: 'header-links'},
+        renderLinkConfigs(CodesearchUI.linkConfigs, tree, version, path, first_match.get('lno'))
+      ),
     ];
-    return h.a({cls: 'label header result-path', href: this.model.matches[0].url()}, repoLabel);
+    return h.div({cls: 'header'}, headerChildren);
   },
 
   render: function() {
@@ -925,6 +984,12 @@ var CodesearchUI = function() {
 CodesearchUI.repo_urls = initData.repo_urls;
 CodesearchUI.internalViewRepos = initData.internal_view_repos;
 CodesearchUI.defaultSearchRepos = initData.default_search_repos;
+CodesearchUI.linkConfigs = (initData.link_configs || []).map(function(link_config) {
+  if (link_config.whitelistRepoPattern) {
+    link_config.whitelistRepoPattern = new RegExp(link_config.whitelistRepoPattern);
+  }
+  return link_config;
+});
 CodesearchUI.onload();
 }
 


### PR DESCRIPTION
## Summary

This can be used to, for example, add links to open an editor such as "Open in VS Code" or web tools, etc.

Sample `livegrep.json` snippet:

```
"file_links": [
	{
		"label": "Open on GitHub (file only)",
		"url-pattern": "https://github.com/{name}/blob/master/src/{path}",
		"whitelist-repo-pattern": "^([^/]+/)?livegrep$"
	},
	{
		"label": "Open on GitHub (with line)",
		"url-pattern": "https://github.com/{name}/blob/master/src/{path}#L{lno}",
		"whitelist-repo-pattern": "^[^/]+/livegrep$"
	}		
]
```

## Test Plan

Check the following `livegrep.json` configurations:
- No `file_links` key works fine
- An empty `file_links` array works fine
- A link with empty `whitelist-repo-pattern` is shown for all repos
- Links are only shown for repos that match the regex in `whitelist-repo-pattern`

Check this functionality in the UI:
- Clicking a link in the file header uses the line number of the first match for `{lno}`
- Links are shown in each file result header
- Only links that contain `{lno}` are shown beside each matching line

## Screenshot
<img width="899" alt="build search 2018-11-22 19-31-46" src="https://user-images.githubusercontent.com/44286225/48919876-59d91b00-ee8d-11e8-8f50-09ef78be5784.png">
