### PR TITLE
Update CircleCI builds

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -18,7 +18,7 @@ ADD https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-
 RUN tar -C /usr/local/ -xzf /tmp/gcloud.tar.gz
 RUN /usr/local/google-cloud-sdk/install.sh
 
-RUN wget --quiet -O /tmp/bazel-0.16.1-installer-linux-x86_64.sh \
-  'https://github.com/bazelbuild/bazel/releases/download/0.16.1/bazel-0.16.1-installer-linux-x86_64.sh' && \
-  chmod +x /tmp/bazel-0.16.1-installer-linux-x86_64.sh
-RUN /tmp/bazel-0.16.1-installer-linux-x86_64.sh
+RUN wget --quiet -O /tmp/bazel-0.21.0-installer-linux-x86_64.sh \
+  'https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel-0.21.0-installer-linux-x86_64.sh' && \
+  chmod +x /tmp/bazel-0.21.0-installer-linux-x86_64.sh
+RUN /tmp/bazel-0.21.0-installer-linux-x86_64.sh

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -9,7 +9,9 @@ fi
 
 cp .bazelrc.circle .bazelrc
 
-bazel fetch //cmd/...
+bazel fetch //cmd/... \
+  --incompatible_package_name_is_a_function=false \
+  --incompatible_remove_native_http_archive=false
 
 gofmt=$(bazel info output_base)/external/go_sdk/bin/gofmt
 format_errors=$(find . -name '*.go' -print0 | xargs -0 "$gofmt" -l -e)
@@ -19,8 +21,12 @@ if [ "$format_errors" ]; then
     exit 1
 fi
 
-bazel test --test_arg=-test.v //...
-bazel build //...
+bazel test --test_arg=-test.v //... \
+  --incompatible_package_name_is_a_function=false \
+  --incompatible_remove_native_http_archive=false
+bazel build //... \
+  --incompatible_package_name_is_a_function=false \
+  --incompatible_remove_native_http_archive=false
 
 # bazel-bin/client/test/go_default_test -test.repo "$(pwd)/deps/linux"
 


### PR DESCRIPTION
Companion to #204. cc @miikka

This updates the Docker image used by CircleCI to use a newer version
of Bazel (0.21.0). It also adds a few flags to the bazel commands in
the CircleCI build script to account for deprecated usage in some
dependencies.

This build itself won't be using the new image. We'll need to build and push the new image, then update the tag in the `.circleci/config.yml` file.