### PR TITLE
Upgrade org_dropbox_rules to work with Bazel 0.22

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,0 @@
-# These are needed by rules_node
-build --incompatible_package_name_is_a_function=false
-build --incompatible_remove_native_http_archive=false
-query --incompatible_package_name_is_a_function=false
-query --incompatible_remove_native_http_archive=false
-fetch --incompatible_package_name_is_a_function=false
-fetch --incompatible_remove_native_http_archive=false

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -131,7 +131,7 @@ git_repository(
 
 git_repository(
     name = "org_dropbox_rules_node",
-    commit = "720576bd5536390c63dca571d338361d008de3da",
+    commit = "f35666fe95bff69b9c96b95a97973ee5bef108bd",
     remote = "https://github.com/dropbox/rules_node.git",
 )
 


### PR DESCRIPTION
Hello again! Bazel 0.22 was released, it removed `--incompatible_package_name_is_a_function=false`, and the build is broken again. Luckily [rules_node](https://github.com/dropbox/rules_node) got some updates, so the flags in `.bazelrc` are not needed anymore.