### PR TITLE
Switch to the new protobuf rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,0 @@
-# These are needed by rules_protobuf
-build --incompatible_remove_native_http_archive=false
-query --incompatible_remove_native_http_archive=false
-fetch --incompatible_remove_native_http_archive=false

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+# c.f. https://github.com/grpc/grpc/pull/13929
+build --copt=-DGRPC_BAZEL_BUILD

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -158,3 +158,9 @@ package(default_visibility = ["//visibility:public"])
     commit = "7bc80f9355b09466fffabce24d463d65e37fcc0f",
     remote = "https://github.com/grailbio/bazel-compilation-database.git",
 )
+
+git_repository(
+    name = "com_google_googletest",
+    commit = "0ea2d8f8fa1601abb9ce713b7414e7b86f90bc61",
+    remote = "https://github.com/google/googletest",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,11 +9,13 @@ load(
     "@bazel_tools//tools/build_defs/repo:http.bzl",
     "http_archive",
 )
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-git_repository(
-    name = "org_pubref_rules_protobuf",
-    commit = "5f6195e83e06db2fd110626b0f2dc64e345e6618",  # v0.8.2
-    remote = "https://github.com/pubref/rules_protobuf",
+http_archive(
+    name = "build_stack_rules_proto",
+    sha256 = "36f11f56f6eb48a81eb6850f4fb6c3b4680e3fc2d3ceb9240430e28d32c47009",
+    strip_prefix = "rules_proto-d86ca6bc56b1589677ec59abfa0bed784d6b7767",
+    urls = ["https://github.com/stackb/rules_proto/archive/d86ca6bc56b1589677ec59abfa0bed784d6b7767.tar.gz"],
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -116,12 +118,19 @@ new_libgit2_archive(
     version = "0.24.1",
 )
 
-load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_repositories")
+load(
+    "@build_stack_rules_proto//cpp:deps.bzl",
+    "cpp_proto_compile",
+    "cpp_grpc_compile",
+)
 
-cpp_proto_repositories(excludes = [
-    "com_google_protobuf",
-    "org_golang_google_grpc",
-])
+cpp_proto_compile()
+
+cpp_grpc_compile()
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
 
 git_repository(
     name = "io_bazel_buildifier",

--- a/src/proto/BUILD
+++ b/src/proto/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cc_proto_library")
+load("@build_stack_rules_proto//cpp:cpp_grpc_library.bzl", "cpp_grpc_library")
 
 proto_library(
     name = "livegrep_proto",
@@ -16,8 +16,7 @@ go_proto_library(
     visibility = ["//visibility:public"],
 )
 
-cc_proto_library(
+cpp_grpc_library(
     name = "cc_proto",
-    protos = ["livegrep.proto"],
-    with_grpc = True,
+    deps = [":livegrep_proto"],
 )

--- a/src/tools/BUILD
+++ b/src/tools/BUILD
@@ -1,6 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_pubref_rules_protobuf//cpp:rules.bzl", "GRPC_COMPILE_DEPS")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 cc_library(
@@ -14,7 +13,7 @@ cc_library(
         "//src:codesearch",
         "//src/proto:cc_proto",
         "@boost//:bind",
-    ] + GRPC_COMPILE_DEPS,
+    ],
 )
 
 cc_binary(


### PR DESCRIPTION
This will fix the need for `--incompatible-*` options in .bazelrc. Also, `pubref/rules_protobuf` is deprecated so we need to upgrade anyways.

Not yet passing tests.

cc @miikka 