### PR TITLE
Allow GitHub-style line range anchors

### DIFF
--- a/web/src/fileview/fileview.js
+++ b/web/src/fileview/fileview.js
@@ -51,7 +51,7 @@ function setHash(hash) {
 }
 
 function parseHashForLineRange(hashString) {
-  var parseMatch = hashString.match(/#L(\d+)(?:-(\d+))?/);
+  var parseMatch = hashString.match(/#L(\d+)(?:-L?(\d+))?/);
 
   if(parseMatch && parseMatch.length === 3) {
     // We have a match on the regex expression


### PR DESCRIPTION
When linking to a range in GitHub, the syntax is #L43-L70. With livegrep,
the syntax is #L43-70. This inconsistency causes me to make a lot of
mistakes.

This patch makes the fileview frontend accept both anchor styles for
linking to line ranges.

cc @nelhage 