### PR TITLE
Add a flag to include submodules when walking the tree.

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -67,10 +67,11 @@ type IndexConfig struct {
 }
 
 type RepoConfig struct {
-	Path      string            `json:"path"`
-	Name      string            `json:"name"`
-	Revisions []string          `json:"revisions"`
-	Metadata  map[string]string `json:"metadata"`
+	Path           string            `json:"path"`
+	Name           string            `json:"name"`
+	Revisions      []string          `json:"revisions"`
+	Metadata       map[string]string `json:"metadata"`
+	WalkSubmodules bool              `json:"walk_submodules"`
 }
 
 type LinkConfig struct {

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -21,7 +21,8 @@ public:
     git_indexer(code_searcher *cs,
                 const std::string& repopath,
                 const std::string& name,
-                const Metadata &metadata);
+                const Metadata &metadata,
+                bool walk_submodules);
     ~git_indexer();
     void walk(const std::string& ref);
 protected:
@@ -32,8 +33,11 @@ protected:
     code_searcher *cs_;
     git_repository *repo_;
     const indexed_tree *idx_tree_;
+    std::string repopath_;
     std::string name_;
     Metadata metadata_;
+    bool walk_submodules_;
+    std::string submodule_prefix_;
 };
 
 #endif

--- a/src/proto/config.proto
+++ b/src/proto/config.proto
@@ -24,4 +24,5 @@ message RepoSpec {
     string name = 2               [json_name = "name"];
     repeated string revisions = 3 [json_name = "revisions"];
     Metadata metadata = 4         [json_name = "metadata"];
+    bool walk_submodules = 5      [json_name = "walk_submodules"];
 }

--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -103,9 +103,9 @@ void build_index(code_searcher *cs, const vector<std::string> &argv) {
     }
 
     for (auto &repo  : spec.repos()) {
-        fprintf(stderr, "Walking repo_spec name=%s, path=%s\n",
-                repo.name().c_str(), repo.path().c_str());
-        git_indexer indexer(cs, repo.path(), repo.name(), repo.metadata());
+        fprintf(stderr, "Walking repo_spec name=%s, path=%s (including  submodules: %s)\n",
+                repo.name().c_str(), repo.path().c_str(), repo.walk_submodules() ? "true" : "false");
+        git_indexer indexer(cs, repo.path(), repo.name(), repo.metadata(), repo.walk_submodules());
         for (auto &rev : repo.revisions()) {
             fprintf(stderr, "  walking %s... ", rev.c_str());
             indexer.walk(rev);


### PR DESCRIPTION
The flag, when set to true, will treat submodules as though they
are just regular files inside the parent repo. The submodule is
indexed at the revision that the parent repo points to.

Fixes livegrep/livegrep#216