### PR TITLE
Ability to set number of context lines per request

### DIFF
--- a/src/codesearch.cc
+++ b/src/codesearch.cc
@@ -43,8 +43,6 @@ using re2::RE2;
 using re2::StringPiece;
 using namespace std;
 
-const int    kContextLines = 3;
-
 const size_t kMinSkip = 250;
 const int kMinFilterRatio = 50;
 const int kMaxScan        = (1 << 20);
@@ -1027,7 +1025,7 @@ void searcher::try_match(const StringPiece& line,
         StringPiece l = line;
         int i = 0;
 
-        for (i = 0; i < kContextLines; i++) {
+        for (i = 0; i < query_->context_lines; i++) {
             if (l.data() == bit->data()) {
                 if (bit == sf->content->begin(cc_->alloc_.get()))
                     break;
@@ -1040,7 +1038,7 @@ void searcher::try_match(const StringPiece& line,
 
         l = line;
 
-        for (i = 0; i < kContextLines; i++) {
+        for (i = 0; i < query_->context_lines; i++) {
             if (l.data() + l.size() == fit->data() + fit->size()) {
                 if (++fit == sf->content->end(cc_->alloc_.get()))
                     break;

--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -124,6 +124,7 @@ struct query {
     } negate;
 
     bool filename_only;
+    int context_lines;
 };
 
 class code_searcher {

--- a/src/proto/livegrep.proto
+++ b/src/proto/livegrep.proto
@@ -13,6 +13,7 @@ message Query {
     string not_tags = 8;
     int32 max_matches = 9;
     bool filename_only = 10;
+    int32 context_lines = 11;
 }
 
 message Bounds {

--- a/src/tagsearch.cc
+++ b/src/tagsearch.cc
@@ -100,12 +100,11 @@ bool tag_searcher::transform(query *q, match_result *m) const {
     // iterate through the lines to add context information
     auto line_it = file->content->begin(file_alloc_);
     auto line_end = file->content->end(file_alloc_);
-    const int kContextLines = 3;
     m->file = file;
 
     // jump to context before
     int current = 1;
-    for (;current < std::max(1, m->lno - kContextLines); ++current)
+    for (;current < std::max(1, m->lno - q->context_lines); ++current)
         ++line_it;
 
     // context before (we reverse the order to match codesearch)
@@ -132,7 +131,7 @@ bool tag_searcher::transform(query *q, match_result *m) const {
 
     // context after
     m->context_after.clear();
-    for (int i = 0; i < kContextLines && line_it != line_end; ++i) {
+    for (int i = 0; i < q->context_lines && line_it != line_end; ++i) {
         m->context_after.push_back(*line_it);
         ++line_it;
     }

--- a/src/tools/grpc_server.cc
+++ b/src/tools/grpc_server.cc
@@ -28,6 +28,7 @@ using grpc::StatusCode;
 
 using std::string;
 
+DEFINE_int32(context_lines, 3, "The default number of result context lines to provide for a single query.");
 DEFINE_int32(max_matches, 50, "The default maximum number of matches to return for a single query.");
 
 class CodeSearchImpl final : public CodeSearch::Service {
@@ -143,6 +144,10 @@ Status parse_query(query *q, const ::Query* request, ::CodeSearchResult* respons
     if (status.ok())
         status = extract_regex(&q->negate.tags_pat, "-tags", request->not_tags());
     q->filename_only = request->filename_only();
+    q->context_lines = request->context_lines();
+    if (q->context_lines <= 0 && FLAGS_context_lines) {
+        q->context_lines = FLAGS_context_lines;
+    }
     return status;
 }
 


### PR DESCRIPTION
This change allows customizing the number of context lines returned on a per-request basis. It involves the following patches:

- Additional field in the search request proto definition for the client to specify the number of context lines
- Additional `codesearch` runtime flag to set the default number of context lines if not specified in the request (defaulted to `3` so to not change existing behavior)
- Augment the `query` struct with `context_lines` to store this value, to be accessed in main search logic where `kContextLines` was previously read

This should be a non-breaking change for the first-party livegrep UI since the "Context" on/off checkbox operates only at the UI layer (by simply choosing not to render the before/after context).

Please feel free to close this PR if this isn't a change you're interested in merging. This is one of several patches we have made to our fork of livegrep that I thought would be a bit easier than the rest to contribute back upstream.