### PR TITLE
Revert "livegrep-github-index: Update HEAD as well as other refs"

### DIFF
--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -457,14 +457,7 @@ func checkoutOne(dir string, depth int, http bool, r *github.Repository) error {
 		return callGit("git", args, *flagGithubKey)
 	}
 
-	// Pass explicit refspecs so we also fetch HEAD as well as
-	// refs/*. We could update config to do this, but it's easier
-	// to just pass it in as we need it.
-	//
-	// Without this, HEAD will forever point to whatever branch it
-	// pointed to during `clone`, even if it is later changed on
-	// the remote.
-	args := []string{"--git-dir", checkout, "fetch", "-p", "origin", "+HEAD:HEAD", "+refs/*:refs/*"}
+	args := []string{"--git-dir", checkout, "fetch", "-p"}
 	if depth != 0 {
 		args = append(args, fmt.Sprintf("--depth=%d", depth))
 	}


### PR DESCRIPTION
This reverts commit ee04aebd09c7847c1aae4eb6b086ace9f91affe3.

fixes #237 (although we should really add tests)
regresses #220, but the previous fix was kinda wonky anyways, since adding `HEAD` to your fetchspec doesn't actually work quite like I'd thought it did…