### PR TITLE
Include unique index identity in search result response

### DIFF
--- a/src/proto/livegrep.proto
+++ b/src/proto/livegrep.proto
@@ -70,6 +70,9 @@ message CodeSearchResult {
     SearchStats stats = 1;
     repeated SearchResult results = 2;
     repeated FileResult file_results = 3;
+    // unique index identity that served this request
+    string index_name = 4;
+    int64 index_time = 5;
 }
 
 message InfoRequest {

--- a/src/tools/grpc_server.cc
+++ b/src/tools/grpc_server.cc
@@ -281,6 +281,9 @@ Status CodeSearchImpl::Search(ServerContext* context, const ::Query* request, ::
 
     scoped_trace_id trace(trace_id_from_request(context));
 
+    response->set_index_name(cs_->name());
+    response->set_index_time(cs_->index_timestamp());
+
     query q;
     Status st;
     st = parse_query(&q, request, response);


### PR DESCRIPTION
This change proposes the inclusion of two new fields, `index_name` and `index_time` (the config-specified name of the index and the current index timestamp, respectively) in the `CodeSearchResult` message. Both of these field values are obtained from the existing server implementation's member variables.

This ties a unique index identity with every search result (i.e., a search request + one state of the index can deterministically be transformed into a search result). In our deployment of livegrep, the index file is rolled several times per day, so the same search request can yield a different set of results throughout the day.

Our livegrep client leverages a distributed caching layer that caches search results (keyed by a serialization of the query), and including a unique index identity in the search response allows for a more robust cache key design. By encoding the index name and timestamp in the key, whenever a new index is loaded by the server, all existing cache keys will be immediately invalid (since the index timestamp has now changed).

Let me know what you think--feel free to close if you feel this use case is too niche.