### PR TITLE
End-to-end server-side search latency stat

### DIFF
--- a/src/proto/livegrep.proto
+++ b/src/proto/livegrep.proto
@@ -45,6 +45,7 @@ message SearchStats {
     int64 sort_time = 3;
     int64 index_time = 4;
     int64 analyze_time = 5;
+    int64 total_time = 7;
     enum ExitReason {
         NONE = 0;
         TIMEOUT = 1;

--- a/src/tools/grpc_server.cc
+++ b/src/tools/grpc_server.cc
@@ -337,6 +337,7 @@ Status CodeSearchImpl::Search(ServerContext* context, const ::Query* request, ::
         ;
 
     match_stats stats;
+    timer search_tm(true);
     if (q.tags_pat == NULL && tagdata_ && might_match_tags) {
         CodeSearchImpl::TagsFirstSearch_(response, q, stats);
     } else if (q.tags_pat == NULL) {
@@ -355,6 +356,7 @@ Status CodeSearchImpl::Search(ServerContext* context, const ::Query* request, ::
         add_match cb(&ls, response);
         run_tags_search(q, line_pat, tagdata_, cb, tagmatch_, stats);
     }
+    search_tm.pause();
 
     auto out_stats = response->mutable_stats();
     out_stats->set_re2_time(timeval_ms(stats.re2_time));
@@ -362,6 +364,7 @@ Status CodeSearchImpl::Search(ServerContext* context, const ::Query* request, ::
     out_stats->set_sort_time(timeval_ms(stats.sort_time));
     out_stats->set_index_time(timeval_ms(stats.index_time));
     out_stats->set_analyze_time(timeval_ms(stats.analyze_time));
+    out_stats->set_total_time(timeval_ms(search_tm.elapsed()));
     switch (stats.why) {
     case kExitNone:
         out_stats->set_exit_reason(SearchStats::NONE);


### PR DESCRIPTION
I've noticed that multithreaded searches (`--threads` param > 0) over an index with many chunks (built with a small-ish `--chunk_power`) result in inaccurate timings in the returned stats message. I'm guessing this is because the timers are run multiple times, once in each thread, causing the total time to be the sum of all individual latencies. This behavior seems correct from a literal standpoint of what the timers are measuring but also a bit unintuitive.

This change proposes the addition of a field to the stats message for an end-to-end "total" time taken by the search. It is measured at a reasonably high level (implementation of the `search` RPC method) in order to most faithfully capture the total server-side search latency.