### PR TITLE
Interface to bypass server-side match limiter per request

### DIFF
--- a/src/tools/grpc_server.cc
+++ b/src/tools/grpc_server.cc
@@ -293,8 +293,13 @@ Status CodeSearchImpl::Search(ServerContext* context, const ::Query* request, ::
     q.trace_id = current_trace_id();
 
     q.max_matches = request->max_matches();
-    if (q.max_matches <= 0 && FLAGS_max_matches)
+    if (q.max_matches == 0 && FLAGS_max_matches) {
+        // For zero-valued match limits, defer to the command line-specified default
         q.max_matches = FLAGS_max_matches;
+    } else if (q.max_matches < 0) {
+        // For explicitly negative match limits, disable the match limiter entirely
+        q.max_matches = 0;
+    }
 
     log(q.trace_id,
         "processing query line='%s' file='%s' tree='%s' tags='%s' "


### PR DESCRIPTION
This offers a small change to the client API that allows clients to bypass the server-side match-based search limiter.

Proposed behavior: When `max_matches` is specified as 0, we will defer to `FLAGS_max_matches`, which in turn defaults to 50 when not specified. When `max_matches` is specified as any negative integer, we explicitly disable the match limiter (the search itself is still subject to the timeout limiter, if enabled).

This is a deviation from current behavior where a zero or negative value of `max_matches` always defers to `FLAGS_max_matches`.

I believe this PR is the only change needed, since the following logic will ignore the match limit if it is zero-valued:

https://github.com/livegrep/livegrep/blob/beca552bc53f644920d78e64504b2c5a84d952a9/src/codesearch.cc#L140