### PR TITLE
Switch to ignorelist

### DIFF
--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -26,7 +26,7 @@ var (
 	flagApiBaseUrl = flag.String("api-base-url", "https://api.github.com/", "Github API base url")
 	flagGithubKey  = flag.String("github-key", os.Getenv("GITHUB_KEY"), "Github API key")
 	flagRepoDir    = flag.String("dir", "repos", "Directory to store repos")
-	flagBlacklist  = flag.String("blacklist", "", "File containing a list of repositories to blacklist indexing")
+	flagIgnorelist = flag.String("ignorelist", "", "File containing a list of repositories to ignore when indexing")
 	flagIndexPath  = dynamicDefault{
 		display: "${dir}/livegrep.idx",
 		fn:      func() string { return path.Join(*flagRepoDir, "livegrep.idx") },
@@ -73,12 +73,12 @@ func main() {
 		*flagHTTPUsername = "x-access-token"
 	}
 
-	var blacklist map[string]struct{}
-	if *flagBlacklist != "" {
+	var ignorelist map[string]struct{}
+	if *flagIgnorelist != "" {
 		var err error
-		blacklist, err = loadBlacklist(*flagBlacklist)
+		ignorelist, err = loadIgnorelist(*flagIgnorelist)
 		if err != nil {
-			log.Fatalf("loading %s: %s", *flagBlacklist, err)
+			log.Fatalf("loading %s: %s", *flagIgnorelist, err)
 		}
 	}
 
@@ -114,7 +114,7 @@ func main() {
 		log.Fatalln(err.Error())
 	}
 
-	repos = filterRepos(repos, blacklist, !*flagForks, !*flagArchived)
+	repos = filterRepos(repos, ignorelist, !*flagForks, !*flagArchived)
 
 	sort.Sort(ReposByName(repos))
 
@@ -163,7 +163,7 @@ func (r ReposByName) Len() int           { return len(r) }
 func (r ReposByName) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 func (r ReposByName) Less(i, j int) bool { return *r[i].FullName < *r[j].FullName }
 
-func loadBlacklist(path string) (map[string]struct{}, error) {
+func loadIgnorelist(path string) (map[string]struct{}, error) {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -264,7 +264,7 @@ func runJobs(client *github.Client, jobc <-chan loadJob, done <-chan struct{}, o
 }
 
 func filterRepos(repos []*github.Repository,
-	blacklist map[string]struct{},
+	ignorelist map[string]struct{},
 	excludeForks bool, excludeArchived bool) []*github.Repository {
 	var out []*github.Repository
 
@@ -277,8 +277,8 @@ func filterRepos(repos []*github.Repository,
 			log.Printf("Excluding archived %s...", *r.FullName)
 			continue
 		}
-		if blacklist != nil {
-			if _, ok := blacklist[*r.FullName]; ok {
+		if ignorelist != nil {
+			if _, ok := ignorelist[*r.FullName]; ok {
 				continue
 			}
 		}

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -21,13 +21,16 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const BLDeprecatedMessage = "This flag has been deprecated and will be removed in a future release. Please switch to the '-ignorelist' option."
+
 var (
-	flagCodesearch = flag.String("codesearch", path.Join(path.Dir(os.Args[0]), "codesearch"), "Path to the `codesearch` binary")
-	flagApiBaseUrl = flag.String("api-base-url", "https://api.github.com/", "Github API base url")
-	flagGithubKey  = flag.String("github-key", os.Getenv("GITHUB_KEY"), "Github API key")
-	flagRepoDir    = flag.String("dir", "repos", "Directory to store repos")
-	flagIgnorelist = flag.String("ignorelist", "", "File containing a list of repositories to ignore when indexing")
-	flagIndexPath  = dynamicDefault{
+	flagCodesearch   = flag.String("codesearch", path.Join(path.Dir(os.Args[0]), "codesearch"), "Path to the `codesearch` binary")
+	flagApiBaseUrl   = flag.String("api-base-url", "https://api.github.com/", "Github API base url")
+	flagGithubKey    = flag.String("github-key", os.Getenv("GITHUB_KEY"), "Github API key")
+	flagRepoDir      = flag.String("dir", "repos", "Directory to store repos")
+	flagIgnorelist   = flag.String("ignorelist", "", "File containing a list of repositories to ignore when indexing")
+	flagDeprecatedBL = flag.String("blacklist", "", "[DEPRECATED] "+BLDeprecatedMessage)
+	flagIndexPath    = dynamicDefault{
 		display: "${dir}/livegrep.idx",
 		fn:      func() string { return path.Join(*flagRepoDir, "livegrep.idx") },
 	}
@@ -58,6 +61,10 @@ const Workers = 8
 func main() {
 	flag.Parse()
 	log.SetFlags(0)
+
+	if *flagDeprecatedBL != "" {
+		log.Fatalln(BLDeprecatedMessage)
+	}
 
 	if flagRepos.strings == nil &&
 		flagOrgs.strings == nil &&


### PR DESCRIPTION
## About

Switches the name of the flag that allows repos to be ignored while indexing to `-ignorelist`. I decided not to put this flag through a deprecation cycle -- let me know if you'd like me to add back the old flag, and have it prompt to switch to the new version.

## Testing

I didn't see any unit tests for this code, so I tested manually on my development machine.

### Without using the `ignorelist`:

```
$ bazel-bin/cmd/livegrep-github-reindex/darwin_amd64_stripped/livegrep-github-reindex --org livegrep -codesearch bazel-bin/src/tools/codesearch
Updating livegrep/livegrep
Updating livegrep/livegrep.com
Walking repo_spec name=livegrep/livegrep, path=repos/livegrep/livegrep (including  submodules: false)
  walking HEAD... done
Walking repo_spec name=livegrep/livegrep.com, path=repos/livegrep/livegrep.com (including  submodules: false)
  walking HEAD... done
Finalizing...
Building filename index...
repository indexed in 0.180407s
== begin metrics ==
index.bytes 1209606
index.bytes.dedup 1068677
index.content.chunks 1
index.content.ranges 30356
index.data.chunks 1
index.files 212
index.lines 30356
index.lines.dedup 22632
== end metrics ==
```

### With the new `ignorelist` flag.

```
$ cat ignorelist.txt 
livegrep/livegrep.com

$ bazel-bin/cmd/livegrep-github-reindex/darwin_amd64_stripped/livegrep-github-reindex --org livegrep -codesearch bazel-bin/src/tools/codesearch -ignorelist ignorelist.txt
Updating livegrep/livegrep
Walking repo_spec name=livegrep/livegrep, path=repos/livegrep/livegrep (including  submodules: false)
  walking HEAD... done
Finalizing...
Building filename index...
repository indexed in 0.172377s
== begin metrics ==
index.bytes 1197430
index.bytes.dedup 1057235
index.content.chunks 1
index.content.ranges 29879
index.data.chunks 1
index.files 194
index.lines 29879
index.lines.dedup 22262
== end metrics ==
```
