### PR TITLE
Improve commit SHA lookup performance

### DIFF
--- a/server/fileview.go
+++ b/server/fileview.go
@@ -106,7 +106,7 @@ func (s DirListingSort) Less(i, j int) bool {
 
 func gitCommitHash(ref string, repoPath string) (string, error) {
 	out, err := exec.Command(
-		"git", "-C", repoPath, "show", "--quiet", "--pretty=%H", ref,
+		"git", "-C", repoPath, "rev-parse", ref,
 	).Output()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Hey there! 👋 

We were seeing high latencies (~4s) when viewing files inside a repository with a lot of branches (~14000). This was tracked down to this git show invocation.

As far as I can see, git show is built on top of git log. The git log command iterates over every branch head to gather the information it needs to render the standard git log output even if this information is ultimately discarded before being displayed. The git rev-parse command looks up just the information we need in a constant number of disk accesses.

Before:

```
$ time git -C $REPO show --quiet --format="%H" HEAD
ac00907bc674a675bc0de94ceb467cb884e82795

real  0m4.711s
user  0m4.076s
sys   0m0.256s
```

After:

```
$ time git -C $REPO rev-parse HEAD
ac00907bc674a675bc0de94ceb467cb884e82795

real  0m0.003s
user  0m0.004s
sys   0m0.000s
```