### PR TITLE
inotify-based hot index file reloads

### DIFF
--- a/src/lib/BUILD
+++ b/src/lib/BUILD
@@ -1,6 +1,13 @@
 cc_library(
     name = "lib",
-    srcs = glob(["*.cc"]),
+    srcs = [
+        "debug.cc",
+        "metrics.cc",
+        "radix_sort.cc",
+    ] + select({
+        "@bazel_tools//src/conditions:linux_x86_64": ["fs_linux.cc"],
+        "//conditions:default": ["fs_default.cc"],
+    }),
     hdrs = glob(["*.h"]),
     copts = ["-Wno-sign-compare"],
     visibility = ["//visibility:public"],

--- a/src/lib/fs.h
+++ b/src/lib/fs.h
@@ -17,7 +17,7 @@ public:
     fswatcher(const std::string &path);
     ~fswatcher();
 
-    void wait_for_event();
+    bool wait_for_event();
 
 private:
     std::string path_;

--- a/src/lib/fs.h
+++ b/src/lib/fs.h
@@ -1,0 +1,26 @@
+/********************************************************************
+ * livegrep -- fs.h
+ * Copyright (c) 2011-2013 Nelson Elhage
+ *
+ * This program is free software. You may use, redistribute, and/or
+ * modify it under the terms listed in the COPYING file.
+ ********************************************************************/
+#ifndef CODESEARCH_FS_H
+#define CODESEARCH_FS_H
+
+#include <string>
+
+using namespace std;
+
+class fswatcher {
+public:
+    fswatcher(const std::string &path);
+    ~fswatcher();
+
+    void wait_for_event();
+
+private:
+    std::string path_;
+};
+
+#endif

--- a/src/lib/fs_default.cc
+++ b/src/lib/fs_default.cc
@@ -1,0 +1,21 @@
+/********************************************************************
+ * livegrep -- fs_default.cc
+ * Copyright (c) 2011-2013 Nelson Elhage
+ *
+ * This program is free software. You may use, redistribute, and/or
+ * modify it under the terms listed in the COPYING file.
+ ********************************************************************/
+#include "fs.h"
+
+#include <future>
+
+fswatcher::fswatcher(const std::string &path) : path_(path) {}
+
+fswatcher::~fswatcher() {}
+
+void fswatcher::wait_for_event() {
+    fprintf(stderr, "Error: fswatcher is not supported on this platform\n");
+
+    // Block forever.
+    std::promise<void>().get_future().wait();
+}

--- a/src/lib/fs_default.cc
+++ b/src/lib/fs_default.cc
@@ -7,15 +7,12 @@
  ********************************************************************/
 #include "fs.h"
 
-#include <future>
-
 fswatcher::fswatcher(const std::string &path) : path_(path) {}
 
 fswatcher::~fswatcher() {}
 
-void fswatcher::wait_for_event() {
+bool fswatcher::wait_for_event() {
     fprintf(stderr, "Error: fswatcher is not supported on this platform\n");
 
-    // Block forever.
-    std::promise<void>().get_future().wait();
+    return false;
 }

--- a/src/lib/fs_linux.cc
+++ b/src/lib/fs_linux.cc
@@ -24,9 +24,6 @@ fswatcher::fswatcher(const std::string &path) : path_(path) {
 fswatcher::~fswatcher() {
     if (fd >= 0) {
         close(fd);
-        if (wd >= 0) {
-            inotify_rm_watch(fd, wd);
-        }
     }
 }
 

--- a/src/lib/fs_linux.cc
+++ b/src/lib/fs_linux.cc
@@ -1,0 +1,41 @@
+/********************************************************************
+ * livegrep -- fs_linux.cc
+ * Copyright (c) 2011-2013 Nelson Elhage
+ *
+ * This program is free software. You may use, redistribute, and/or
+ * modify it under the terms listed in the COPYING file.
+ ********************************************************************/
+#include "fs.h"
+
+#include <limits.h>
+#include <sys/inotify.h>
+#include <unistd.h>
+
+namespace {
+    int fd = -1;
+    int wd = -1;
+}
+
+fswatcher::fswatcher(const std::string &path) : path_(path) {
+    fd = inotify_init();
+    wd = inotify_add_watch(fd, path.c_str(), IN_ATTRIB | IN_CLOSE_WRITE | IN_MOVE_SELF);
+}
+
+fswatcher::~fswatcher() {
+    if (fd >= 0) {
+        close(fd);
+        if (wd >= 0) {
+            inotify_rm_watch(fd, wd);
+        }
+    }
+}
+
+void fswatcher::wait_for_event() {
+    struct inotify_event event;
+    int n = 0;
+
+    // The read syscall is blocking; it returns after one eligible event (i.e., matching the mask) is received.
+    while (n <= 0) {
+        n = read(fd, &event, sizeof(struct inotify_event) + NAME_MAX + 1);
+    }
+}


### PR DESCRIPTION
This change proposes a new flag `--hot_index_reload` which uses a similar mechanism as `--reload_rpc` to automatically reload the server when the index file on disk changes, using inotify C APIs. This behavior only applies when the server is started with a prebuilt index file (i.e. `--load_index`) and is incompatible with `--reload_rpc` (so that the shutdown thread only waits on a single blocking operations for restarts). As implemented, the server is restarted by touching, copying, or moving a new index to the path specified by `--load_index`.

Our indexing pipeline builds and deploys a new index file every few hours. This change allows the server to automatically pick up the refreshed index without needing to configure a client to issue a manual reload after the deploy completes.

Unfortunately, this only works on Linux due to the use of inotify. Feel free to reject this change if there's a requirement for livegrep to compile cross-platform.