### PR TITLE
gRPC 1.13.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,9 +102,9 @@ http_archive(
 
 git_repository(
     name = "com_github_grpc_grpc",
-    commit = "820f906248b8c6dbbde031715964f63e822a735c",
+    commit = "7d7e4567625db7cfebf8969a225948097a3f9f89",
     remote = "https://github.com/grpc/grpc.git",
-    shallow_since = "1598378801 -0700",
+    shallow_since = "1597651368 +0200",
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")


### PR DESCRIPTION
I've encountered a build error since e719c36f02198d36a65850d5f73ef01ba8e853d8 on Bazel 3.4.1:

```
ERROR: no such package '@com_github_grpc_grpc//bazel': Traceback (most recent call last):
        File "/home/kiwi/.cache/bazel/_bazel_kiwi/9737f374979233968789ebadfccef073/external/bazel_tools/tools/build_defs/repo/git.bzl", line 177
                _clone_or_update(ctx)
        File "/home/kiwi/.cache/bazel/_bazel_kiwi/9737f374979233968789ebadfccef073/external/bazel_tools/tools/build_defs/repo/git.bzl", line 36, in _clone_or_update
                git_repo(ctx, directory)
        File "/home/kiwi/.cache/bazel/_bazel_kiwi/9737f374979233968789ebadfccef073/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 91, in git_repo
                _update(ctx, git_repo)
        File "/home/kiwi/.cache/bazel/_bazel_kiwi/9737f374979233968789ebadfccef073/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 104, in _update
                reset(ctx, git_repo)
        File "/home/kiwi/.cache/bazel/_bazel_kiwi/9737f374979233968789ebadfccef073/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 141, in reset
                _git(ctx, git_repo, "reset", <2 more arguments>)
        File "/home/kiwi/.cache/bazel/_bazel_kiwi/9737f374979233968789ebadfccef073/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 159, in _git
                _error(ctx.name, <2 more arguments>)
        File "/home/kiwi/.cache/bazel/_bazel_kiwi/9737f374979233968789ebadfccef073/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 181, in _error
                fail(<1 more arguments>)
error running 'git reset --hard 820f906248b8c6dbbde031715964f63e822a735c' while working with @com_github_grpc_grpc:
fatal: Could not parse object '820f906248b8c6dbbde031715964f63e822a735c'.
```

which is odd because the commit certainly exists: https://github.com/grpc/grpc/commit/820f906248b8c6dbbde031715964f63e822a735c

There may be something awry with the shallow clone but I'm not enough of a git or Bazel expert to dig into it.

I reset to the commit of the latest stable release tag [1.13.1](https://github.com/grpc/grpc/releases/tag/v1.31.1) and took Bazel's recommendation for `shallow_since`. It seems to work now. Proposing it here as a potential fix in case it's a legitimate issue and not just specific to my environment.