### PR TITLE
Update the name of the RE2 dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,7 +21,7 @@ http_archive(
 )
 
 git_repository(
-    name = "com_googlesource_code_re2",
+    name = "com_github_google_re2",
     commit = "767de83bb7e4bfe3a2d8aec0ec79f9f1f66da30a",
     remote = "https://github.com/google/re2",
     shallow_since = "1535650560 +0000",

--- a/src/BUILD
+++ b/src/BUILD
@@ -15,11 +15,11 @@ cc_library(
         "//third_party:utf8cpp",
         "@boost//:filesystem",
         "@boost//:intrusive_ptr",
+        "@com_github_google_re2//:re2",
         "@com_github_libgit2//:libgit2",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/hash",
         "@com_google_absl//absl/strings",
-        "@com_googlesource_code_re2//:re2",
         "@divsufsort",
     ],
 )


### PR DESCRIPTION
GRPC also depends on RE2, by the `com_github_google_re2` name. The
fact that we were using a different name resulted in GRPC pulling in a
second copy. This used to mostly work fine because they were
ABI-compatible, at least in the pieces we use. However, RE2 recently
updated the layout of a core struct in
572d6abf7f227053a4f8b83381fc4378714a2552, which meant that we ended up
seeing one version of the headers and linking against a different
version of the objects, which was a no good bad time.

IMO this is arguably a bug in GRPC's bazel build -- it should not be
leaking those headers -- but this fix is correct in any case.