### PR TITLE
Encode filename index in index file dump

### DIFF
--- a/src/codesearch.cc
+++ b/src/codesearch.cc
@@ -505,13 +505,12 @@ void code_searcher::index_filenames() {
 void code_searcher::finalize() {
     assert(!finalized_);
     finalized_ = true;
+    index_filenames();
     alloc_->finalize();
 
     timeval now;
     gettimeofday(&now, NULL);
     index_timestamp_ = now.tv_sec;
-
-    index_filenames();
 
     idx_data_chunks.inc(alloc_->end() - alloc_->begin());
     idx_content_chunks.inc(alloc_->end_content() - alloc_->begin_content());

--- a/src/dump_load.h
+++ b/src/dump_load.h
@@ -11,7 +11,7 @@
 #include <stdint.h>
 
 const uint32_t kIndexMagic   = 0xc0d35eac;
-const uint32_t kIndexVersion = 13;
+const uint32_t kIndexVersion = 14;
 const uint32_t kPageSize     = (1 << 12);
 
 struct index_header {
@@ -32,6 +32,11 @@ struct index_header {
 
     uint32_t ncontent;
     uint64_t content_off;
+
+    uint32_t nfiledata;
+    uint64_t filedata_off;
+    uint64_t filesuffixes_off;
+    uint64_t filepos_off;
 } __attribute__((packed));
 
 struct chunk_header {


### PR DESCRIPTION
This change proposal attempts to fix #279. It includes the following high level changes:

- Expand the index header to include sizes and offsets of [all three data structures used to store the filename index](https://github.com/livegrep/livegrep/blob/7b3cccb9c9e6201fb309f72fc4d580807e65bd12/src/codesearch.h#L231)
- Encode said data structures into the dump in a new routine `dump_filename_index` in `codesearch_index`, and decode their contents into a `code_searcher` instance on a `load_index` operation
- Bump the index version constant due to a backwards-incompatibile index file format change
- Remove the `index_filenames()` step invoked when loading an offline-built index file

This seems to work in my very limited manual testing. For an index with ~75M lines of source code over ~300K files, this cuts the gRPC server launch time from ~4s to ~1s on my machine. (It's already quite fast as-is; the startup/reload slowdown mentioned in #279 ended up being due to an unrelated issue)