### PR TITLE
Avoid messy stderr output in some cases

### DIFF
--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -110,9 +110,9 @@ void build_index(code_searcher *cs, const vector<std::string> &argv) {
                 repo.name().c_str(), repo.path().c_str(), repo.walk_submodules() ? "true" : "false");
         git_indexer indexer(cs, repo.path(), repo.name(), repo.metadata(), repo.walk_submodules());
         for (auto &rev : repo.revisions()) {
-            fprintf(stderr, "  walking %s... ", rev.c_str());
+            fprintf(stderr, "  walking %s\n", rev.c_str());
             indexer.walk(rev);
-            fprintf(stderr, "done\n");
+            fprintf(stderr, "  done\n");
         }
     }
 }


### PR DESCRIPTION
If the repo being indexed has files that are too large, a WARN
line is emitted between the "walking HEAD..." and "done" outputs.
This results in messy stderr that looks like this:

  walking HEAD... WARN: file is too big to be indexed
WARN: file2 is too big to be indexed
done

Apart from looking messy, this makes it harder to autodetect
warnings with grep. It seems better to insert a newline
after the "walking HEAD..." output, which also makes it
consistent with the other branch of code immediately above.