### PR TITLE
Add a max-width span around file name link

### DIFF
--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -216,6 +216,10 @@ a:hover {
     padding-right: 3px;
 }
 
+.header-path {
+    flex-grow: 1;
+}
+
 .result-path {
     color: #3d464d;
     font-family: "Menlo", "Consolas", "Monaco", monospace;

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -534,7 +534,7 @@ var FileGroupView = Backbone.View.extend({
             dirname,
             h.span({cls: "filename"}, [basename]),
           ]
-        ),
+        )
       ),
       h.div(
         {cls: 'header-links'},

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -524,14 +524,17 @@ var FileGroupView = Backbone.View.extend({
     var first_match = this.model.matches[0];
 
     var headerChildren = [
-      h.a(
-        {cls: 'result-path', href: first_match.url()},
-        [
-          h.span({cls: "repo"}, [tree, ':']),
-          h.span({cls: "version"}, [shorten(version), ':']),
-          dirname,
-          h.span({cls: "filename"}, [basename]),
-        ]
+      h.span(
+        {cls: 'header-path'},
+        h.a(
+          {cls: 'result-path', href: first_match.url()},
+          [
+            h.span({cls: "repo"}, [tree, ':']),
+            h.span({cls: "version"}, [shorten(version), ':']),
+            dirname,
+            h.span({cls: "filename"}, [basename]),
+          ]
+        ),
       ),
       h.div(
         {cls: 'header-links'},


### PR DESCRIPTION
On the search results page, one thing I've noticed is that copying the path from the header results in a `^M` newline character being copied as well.

One way to reproduce this is to start a search, then click and drag your mouse starting where the red arrow is (e.g., to select the text `web/src/codesearch/codesearch_ui.js`)

<img width="1022" alt="Screen Shot 2021-07-16 at 3 39 37 PM" src="https://user-images.githubusercontent.com/935063/126015130-ae56a685-0af1-4e2f-ae2e-04b1e953d988.png">

When you paste, it also pastes a newline. This adds another step to delete the newline if you're opening a file by pasting the path into something like vim's `:e` command.

To fix, I wrapped the `<a>` in big span. It's bigger than the link, so only the text remains the target, but you can still highlight and not get the newline. No visual differences detected.

Before:
<img width="1019" alt="Screen Shot 2021-07-16 at 3 46 39 PM" src="https://user-images.githubusercontent.com/935063/126015354-7aba0d2c-b890-4fb7-ad5b-9fa0f2a555c9.png">

After:
<img width="1019" alt="Screen Shot 2021-07-16 at 3 46 16 PM" src="https://user-images.githubusercontent.com/935063/126015360-4a9efa18-bd65-4d10-8c21-6ea7c47eff06.png">
