### PR TITLE
Fix path names

### DIFF
--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -526,15 +526,17 @@ var FileGroupView = Backbone.View.extend({
     var headerChildren = [
       h.span(
         {cls: 'header-path'},
-        h.a(
-          {cls: 'result-path', href: first_match.url()},
-          [
-            h.span({cls: "repo"}, [tree, ':']),
-            h.span({cls: "version"}, [shorten(version), ':']),
-            dirname,
-            h.span({cls: "filename"}, [basename]),
-          ]
-        )
+        [
+          h.a(
+            {cls: 'result-path', href: first_match.url()},
+            [
+              h.span({cls: "repo"}, [tree, ':']),
+              h.span({cls: "version"}, [shorten(version), ':']),
+              dirname,
+              h.span({cls: "filename"}, [basename]),
+            ]
+          ),
+        ]
       ),
       h.div(
         {cls: 'header-links'},


### PR DESCRIPTION
Fixes bug #305, which was introduced in #303. 

This time I got the right version of bazel and tested it locally all the way. Sorry. The second argument to `h.span` needs to be an array, even if there is only one element as children.