### PR TITLE
allow github-live-reindex to generate config file for file viewer

### DIFF
--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -46,7 +46,7 @@ func main() {
 		log.Fatalf("reading %s: %s", flag.Arg(0), err.Error())
 	}
 
-	if err := checkoutRepos(&cfg.Repos); err != nil {
+	if err := checkoutRepos(&cfg.Repositories); err != nil {
 		log.Fatalln(err.Error())
 	}
 

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -37,8 +37,9 @@ var (
 		fn:      func() string { return path.Join(*flagRepoDir, "livegrep.idx") },
 	}
 	flagRevision     = flag.String("revision", "HEAD", "git revision to index")
-	flagRevparse     = flag.Bool("revparse", true, "whether to `git rev-parse` the provided revision in generated links")
+	flagUrlPattern   = flag.String("url-pattern", "https://github.com/{name}/blob/{version}/{path}#L{lno}", "when using the local frontend fileviewer, this string will be used to construt a link to the file source on github")
 	flagName         = flag.String("name", "livegrep index", "The name to be stored in the index file")
+	flagRevparse     = flag.Bool("revparse", true, "whether to `git rev-parse` the provided revision in generated links")
 	flagForks        = flag.Bool("forks", true, "whether to index repositories that are github forks, and not original repos")
 	flagArchived     = flag.Bool("archived", false, "whether to index repositories that are archived on github")
 	flagHTTP         = flag.Bool("http", false, "clone repositories over HTTPS instead of SSH")
@@ -406,13 +407,14 @@ func buildConfig(name string,
 			password_env = "GITHUB_KEY"
 		}
 
-		cfg.Repos = append(cfg.Repos, &config.RepoSpec{
+		cfg.Repositories = append(cfg.Repositories, &config.RepoSpec{
 			Path:      path.Join(dir, *r.FullName),
 			Name:      *r.FullName,
 			Revisions: []string{revision},
 			Metadata: &config.Metadata{
-				Github: *r.HTMLURL,
-				Remote: remote,
+				Github:     *r.HTMLURL,
+				Remote:     remote,
+				UrlPattern: *flagUrlPattern,
 			},
 			CloneOptions: &config.CloneOptions{
 				Depth:       int32(*flagDepth),

--- a/doc/examples/livegrep/index.json
+++ b/doc/examples/livegrep/index.json
@@ -5,7 +5,7 @@
             "name": "livegrep/livegrep",
             "path": "src/",
             "metadata": {
-                "url-pattern": "https://github.com/{name}/blob/HEAD/src/{path}#L{lno}"
+                "url_pattern": "https://github.com/{name}/blob/{version}/src/{path}#L{lno}"
             }
         }
     ],
@@ -15,7 +15,8 @@
             "path": ".",
             "revisions": [ "HEAD" ],
             "metadata": {
-                "github": "livegrep/livegrep"
+                "github": "livegrep/livegrep",
+                "url_pattern": "https://github.com/{name}/blob/{version}/src/{path}#L{lno}"
             }
         }
     ]

--- a/doc/examples/livegrep/index_with_ordered_contents.json
+++ b/doc/examples/livegrep/index_with_ordered_contents.json
@@ -6,7 +6,7 @@
             "path": "src/",
             "ordered-contents": "ordered-contents.txt",
             "metadata": {
-                "url-pattern": "https://github.com/{name}/blob/HEAD/src/{path}#L{lno}"
+                "url_pattern": "https://github.com/{name}/blob/{version}/src/{path}#L{lno}"
             }
         }
     ],

--- a/server/fileview.go
+++ b/server/fileview.go
@@ -255,7 +255,7 @@ func buildFileData(relativePath string, repo config.RepoConfig, commit string) (
 	}
 
 	externalDomain := "external viewer"
-	if url, err := url.Parse(repo.Metadata["url-pattern"]); err == nil {
+	if url, err := url.Parse(repo.Metadata["url_pattern"]); err == nil {
 		externalDomain = url.Hostname()
 	}
 

--- a/src/proto/config.proto
+++ b/src/proto/config.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 message IndexSpec {
     string name = 1;
     repeated PathSpec paths = 2 [json_name = "fs_paths"];
-    repeated RepoSpec repos = 3 [json_name = "repositories"];
+    repeated RepoSpec repositories = 3 [json_name = "repositories"];
 }
 
 message Metadata {
-    string url_pattern = 1     [json_name = "url-pattern"];
+    string url_pattern = 1     [json_name = "url_pattern"];
     string remote = 2          [json_name = "remote"];
     string github = 3          [json_name = "github"];
     repeated string labels = 4 [json_name = "labels"];
@@ -22,7 +22,7 @@ message CloneOptions {
 message PathSpec {
     string path = 1             [json_name = "path"];
     string name = 2             [json_name = "name"];
-    string ordered_contents = 3 [json_name = "ordered-contents"];
+    string ordered_contents = 3 [json_name = "ordered_contents"];
     Metadata metadata = 4       [json_name = "metadata"];
 }
 

--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -83,7 +83,7 @@ void build_index(code_searcher *cs, const vector<std::string> &argv) {
         fprintf(stderr, "Parsing %s: %s\n", argv[1].c_str(), status.error_message().data());
         exit(1);
     }
-    if (!spec.paths_size() && !spec.repos_size()) {
+    if (!spec.paths_size() && !spec.repositories_size()) {
         fprintf(stderr, "%s: You must specify at least one path to index.\n", argv[1].c_str());
         exit(1);
     }
@@ -105,7 +105,7 @@ void build_index(code_searcher *cs, const vector<std::string> &argv) {
         fprintf(stderr, "done\n");
     }
 
-    for (auto &repo  : spec.repos()) {
+    for (auto &repo  : spec.repositories()) {
         fprintf(stderr, "Walking repo_spec name=%s, path=%s (including  submodules: %s)\n",
                 repo.name().c_str(), repo.path().c_str(), repo.walk_submodules() ? "true" : "false");
         git_indexer indexer(cs, repo.path(), repo.name(), repo.metadata(), repo.walk_submodules());

--- a/web/src/fileview/fileview.js
+++ b/web/src/fileview/fileview.js
@@ -168,7 +168,13 @@ function init(initData) {
     var repoName = initData.repo_info.name;
     var filePath = initData.file_path;
 
-    url = initData.repo_info.metadata['url-pattern']
+    url = initData.repo_info.metadata['url_pattern'];
+
+    // If url not found, warn user and fail gracefully
+    if (!url) { // deal with both undefined and empty string
+        console.error("The index file you provided does not provide repositories[x].metadata.url_pattern. External links to file sources will not work. See the README for more information on file viewing.");
+        return;
+    }
 
     // If {path} already has a slash in front of it, trim extra leading
     // slashes from `pathInRepo` to avoid a double-slash in the URL.


### PR DESCRIPTION
The switch in 8c639ff5f1b7e3916ed1c480eeab6bc50c4f8c73 to use the
protobuf config files made it so that the config file written by
github-live-reindex stored repoitories under `repos` instead of
`repositories` as google/protobuf does not support custom json
tags in structs. Did the easy thing and normalized every instance
of IndexConfig/IndexSpec to use `repositories`, instead of `repos`
in some places and `repositories` in others. I considered changing the
json tags at runtime with a package like https://github.com/fatih/structtag, 
but I figured this was easier. 

also add file view/repository browser section to readme and
add graceful failure handling if url_pattern is not present for
repos in config file
change examples of `url_pattern` to use `{version}` because the
frontend overrides it.

I also added documentation for how to set up the frontend

If there's anything you'd like me to change or revisit just let me know!