### PR TITLE
bump PerPage value for gh-reindexer repo fetching to max

### DIFF
--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -328,7 +328,7 @@ func getOneRepo(client *github.Client, repo string) ([]*github.Repository, error
 func getOrgRepos(client *github.Client, org string) ([]*github.Repository, error) {
 	var buf []*github.Repository
 	opt := &github.RepositoryListByOrgOptions{
-		ListOptions: github.ListOptions{PerPage: 50},
+		ListOptions: github.ListOptions{PerPage: 100},
 	}
 	for {
 		repos, resp, err := client.Repositories.ListByOrg(context.TODO(), org, opt)
@@ -347,7 +347,7 @@ func getOrgRepos(client *github.Client, org string) ([]*github.Repository, error
 func getUserRepos(client *github.Client, user string) ([]*github.Repository, error) {
 	var buf []*github.Repository
 	opt := &github.RepositoryListOptions{
-		ListOptions: github.ListOptions{PerPage: 50},
+		ListOptions: github.ListOptions{PerPage: 100},
 	}
 	for {
 		repos, resp, err := client.Repositories.List(context.TODO(), user, opt)


### PR DESCRIPTION
~~Small change to allow the number of repos per GitHub api request to be configurable. I mention the max is 100, but don't do any validation because the GH REST api does it. `go-github` doesn't validate this either, as far as I [can tell](https://github.com/google/go-github/blob/85425ec5f1e4118be4b578e5b6ad07f9ea32cf5f/github/repos.go#L283).  This is change 2 from issue #313~~

PR now simply bumps the PerPage number to `100`, which is the max allowed by the github REST api. Should have no effect on users/orgs that have less than 100  repos, while always reducing the num of network calls made for those that have >= 100 repos.  