### PR TITLE
Concurrent reindexer GitHub requests

### DIFF
--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -24,9 +24,8 @@ var (
 	flagRevparse      = flag.Bool("revparse", true, "whether to `git rev-parse` the provided revision in generated links")
 	flagSkipMissing   = flag.Bool("skip-missing", false, "skip repositories where the specified revision is missing")
 	flagReloadBackend = flag.String("reload-backend", "", "Backend to send a Reload RPC to")
+	flagNumWorkers    = flag.Int("num-workers", 8, "Number of workers used to update repositories")
 )
-
-const Workers = 8
 
 func main() {
 	flag.Parse()
@@ -99,11 +98,11 @@ func findCodesearch(given string) string {
 
 func checkoutRepos(repos *[]*config.RepoSpec) error {
 	repoc := make(chan *config.RepoSpec)
-	errc := make(chan error, Workers)
+	errc := make(chan error, *flagNumWorkers)
 	stop := make(chan struct{})
 	wg := sync.WaitGroup{}
-	wg.Add(Workers)
-	for i := 0; i < Workers; i++ {
+	wg.Add(*flagNumWorkers)
+	for i := 0; i < *flagNumWorkers; i++ {
 		go func() {
 			defer wg.Done()
 			checkoutWorker(repoc, stop, errc)

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -366,10 +366,12 @@ func callGitHubConcurrently(initialResp *github.Response, concurrencyLimit int, 
 
 			var repos []*github.Repository
 			var err error
+			var resp *github.Response
 			if method == "org" {
-				repos, _, err = gClient.Repositories.ListByOrg(context.TODO(), org, &github.RepositoryListByOrgOptions{
+				repos, resp, err = gClient.Repositories.ListByOrg(context.TODO(), org, &github.RepositoryListByOrgOptions{
 					ListOptions: github.ListOptions{PerPage: *flagReposPerPage, Page: page},
 				})
+				log.Printf("remaining rate: %d", resp.Rate.Remaining)
 			} else if method == "user" {
 				repos, _, err = gClient.Repositories.List(context.TODO(), user, &github.RepositoryListOptions{
 					ListOptions: github.ListOptions{PerPage: *flagReposPerPage, Page: page},

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -362,11 +362,11 @@ func callGitHubConcurrently(initialResp *github.Response, concurrencyLimit int, 
 			var err error
 			if method == "org" {
 				repos, _, err = gClient.Repositories.ListByOrg(ctx, org, &github.RepositoryListByOrgOptions{
-					ListOptions: github.ListOptions{PerPage: *flagReposPerPage, Page: page},
+					ListOptions: github.ListOptions{PerPage: 100, Page: page},
 				})
 			} else if method == "user" {
 				repos, _, err = gClient.Repositories.List(ctx, user, &github.RepositoryListOptions{
-					ListOptions: github.ListOptions{PerPage: *flagReposPerPage, Page: page},
+					ListOptions: github.ListOptions{PerPage: 100, Page: page},
 				})
 			}
 

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -40,6 +40,7 @@ var (
 	flagRevision                = flag.String("revision", "HEAD", "git revision to index")
 	flagUrlPattern              = flag.String("url-pattern", "https://github.com/{name}/blob/{version}/{path}#L{lno}", "when using the local frontend fileviewer, this string will be used to construt a link to the file source on github")
 	flagName                    = flag.String("name", "livegrep index", "The name to be stored in the index file")
+	flagNumRepoUpdateWorkers    = flag.String("num-repo-update-workers", "8", "Number of workers fetch-reindex will use to update repositories")
 	flagRevparse                = flag.Bool("revparse", true, "whether to `git rev-parse` the provided revision in generated links")
 	flagForks                   = flag.Bool("forks", true, "whether to index repositories that are github forks, and not original repos")
 	flagArchived                = flag.Bool("archived", false, "whether to index repositories that are archived on github")
@@ -49,9 +50,10 @@ var (
 	flagDepth                   = flag.Int("depth", 0, "clone repository with specify --depth=N depth.")
 	flagSkipMissing             = flag.Bool("skip-missing", false, "skip repositories where the specified revision is missing")
 	flagMaxConcurrentGHRequests = flag.Int("max-concurrent-gh-requests", 1, "Applied per org/user. If fetching 2 orgs, you will have 2x{yourInput} network calls possible at a time")
-	flagRepos                   = stringList{}
-	flagOrgs                    = stringList{}
-	flagUsers                   = stringList{}
+
+	flagRepos = stringList{}
+	flagOrgs  = stringList{}
+	flagUsers = stringList{}
 )
 
 func init() {
@@ -150,6 +152,7 @@ func main() {
 	args := []string{
 		"--out", index,
 		"--codesearch", *flagCodesearch,
+		"--num-workers", *flagNumRepoUpdateWorkers,
 	}
 	if *flagRevparse {
 		args = append(args, "--revparse")

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -356,6 +356,7 @@ func callGitHubConcurrently(initialResp *github.Response, concurrencyLimit int, 
 	var wg sync.WaitGroup
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	for i := 1; i <= pagesToCall; i++ {
 		wg.Add(1)
@@ -368,12 +369,12 @@ func callGitHubConcurrently(initialResp *github.Response, concurrencyLimit int, 
 			var err error
 			var resp *github.Response
 			if method == "org" {
-				repos, resp, err = gClient.Repositories.ListByOrg(context.TODO(), org, &github.RepositoryListByOrgOptions{
+				repos, resp, err = gClient.Repositories.ListByOrg(ctx, org, &github.RepositoryListByOrgOptions{
 					ListOptions: github.ListOptions{PerPage: *flagReposPerPage, Page: page},
 				})
 				log.Printf("remaining rate: %d", resp.Rate.Remaining)
 			} else if method == "user" {
-				repos, _, err = gClient.Repositories.List(context.TODO(), user, &github.RepositoryListOptions{
+				repos, _, err = gClient.Repositories.List(ctx, user, &github.RepositoryListOptions{
 					ListOptions: github.ListOptions{PerPage: *flagReposPerPage, Page: page},
 				})
 			}
@@ -389,19 +390,15 @@ func callGitHubConcurrently(initialResp *github.Response, concurrencyLimit int, 
 	}
 
 	// close the channel in the background
-	// don't close over wg here, so no need to pass in like in for loop go funcs
 	go func() {
 		wg.Wait()
 		close(resStream)
 		close(semaphores)
 	}()
 
-	// read from channel as they come in until its closed
-
 	for res := range resStream {
 		if res.err != nil {
-			cancel() // cancel the other network requests going on
-			return nil, res.err
+			return nil, res.err // cancel will be called after this early return
 		}
 		resultsMatrix[res.Page-1] = res.Repos // Page index is 1 based
 	}
@@ -416,7 +413,7 @@ func callGitHubConcurrently(initialResp *github.Response, concurrencyLimit int, 
 }
 
 func getOrgRepos(client *github.Client, org string) ([]*github.Repository, error) {
-	defer timeTrack(time.Now(), "getOrgRepos")
+	defer timeTrack(time.Now(), fmt.Sprintf("getOrgRepos - %s", org))
 	log.Printf("Fetching repositories for organization: %s", org)
 
 	opt := &github.RepositoryListByOrgOptions{
@@ -426,7 +423,7 @@ func getOrgRepos(client *github.Client, org string) ([]*github.Repository, error
 
 	if err != nil {
 		return nil, err
-	} else if resp.LastPage == 1 { // if no more pages, return early
+	} else if resp.FirstPage == resp.LastPage { // if no more pages, return early
 		return repos, nil
 	}
 
@@ -435,17 +432,16 @@ func getOrgRepos(client *github.Client, org string) ([]*github.Repository, error
 }
 
 func getUserRepos(client *github.Client, user string) ([]*github.Repository, error) {
-	defer timeTrack(time.Now(), "getUserRepos")
+	defer timeTrack(time.Now(), fmt.Sprintf("getUserRepos - %s", user))
 	log.Printf("Fetching repositories for user: %s", user)
 
 	opt := &github.RepositoryListOptions{
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
 	repos, resp, err := client.Repositories.List(context.TODO(), user, opt)
-
 	if err != nil {
 		return nil, err
-	} else if resp.LastPage == 1 { // if no more pages, return early
+	} else if resp.FirstPage == resp.LastPage { // if no more pages, return early
 		return repos, nil
 	}
 


### PR DESCRIPTION
This change does two things:
1. allows `livegrep-github-reindex` to make requests for repos (per user or per org) concurrently at a specified limit. By default it's set to 1, which retains the current behavior wherein only 1 call pero user/org is made at a time. Settings the limit to ~40 for me dropped the time the `updating repos` step took from ~1min to ~5s when indexing 2 orgs with a combined ~4k repos.
2. adds a new flag, `num-workers` to `livegrep-fetch-reindex` that updates the number of workers used to run the `checkoutRepos` function. Also updates `livegrep-github-reindex` and adds the arg `num-repo-update-workers` whose value will be bassed to the call to `livegrep-fetch-reindex` as `num-workers`

For the concurrent requests, I made the decision to try to retain order (the results of `repos?page=1` come before `repos?page=2` and so on), in case someone is expecting/relying on their repos to be updated/cloned/indexed in the order they're listed by the github api. Could remove some complexity if we decide that order isn't a big deal. Also, once things look god I can squash and clean up history a bit.

This is items 3 and 4 in #313 .

If any questions/comments at all let me know!
