### PR TITLE
Add option for noindex to livegrep-github-reindex

### DIFF
--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -140,7 +140,7 @@ func main() {
 	if err := writeConfig(config, configPath); err != nil {
 		log.Fatalln(err.Error())
 	}
-	if flagNoIndex {
+	if *flagNoIndex {
 		log.Printf("Skipping indexing after writing config")
 		return
 	}

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -49,6 +49,7 @@ var (
 	flagDepth                   = flag.Int("depth", 0, "clone repository with specify --depth=N depth.")
 	flagSkipMissing             = flag.Bool("skip-missing", false, "skip repositories where the specified revision is missing")
 	flagMaxConcurrentGHRequests = flag.Int("max-concurrent-gh-requests", 1, "Applied per org/user. If fetching 2 orgs, you will have 2x{yourInput} network calls possible at a time")
+	flagNoIndex                 = flag.Bool("no-index", false, "Skip indexing after writing config")
 
 	flagRepos = stringList{}
 	flagOrgs  = stringList{}
@@ -138,6 +139,10 @@ func main() {
 	configPath := path.Join(*flagRepoDir, "livegrep.json")
 	if err := writeConfig(config, configPath); err != nil {
 		log.Fatalln(err.Error())
+	}
+	if (flagNoIndex) {
+		log.Printf("Skipping indexing after writing config")
+		return
 	}
 
 	index := flagIndexPath.Get().(string)

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -140,7 +140,7 @@ func main() {
 	if err := writeConfig(config, configPath); err != nil {
 		log.Fatalln(err.Error())
 	}
-	if (flagNoIndex) {
+	if flagNoIndex {
 		log.Printf("Skipping indexing after writing config")
 		return
 	}


### PR DESCRIPTION
This PR adds a flag to skip indexing in `cmd/livegrep-github-reindex/main.go`. At Stripe we use livegrep over a couple instances of GitHub, so our re-index operation calls this command a few times, combines the index, and generates the final index. This means that we are indexing `n + 1` times (where n is the number of GitHub locations) but only the last one matters.

This PR adds an easy option to simply return after indexing.

