### PR TITLE
Add typescript highlighting for .ts files

### DIFF
--- a/server/fileview.go
+++ b/server/fileview.go
@@ -50,6 +50,7 @@ var extToLangMap map[string]string = map[string]string{
 	".sky":         "python",
 	".sql":         "sql",
 	".swift":       "swift",
+	".ts":          "typescript",
 	".tsx":         "tsx",
 	".xml":         "markup",
 	".yaml":        "yaml",


### PR DESCRIPTION
This should let https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/components/prism-typescript.min.js autoload for `.ts` files.

Some day I'll get around to a PR for the config options for this list, like I mentioned in #300 😅 