### PR TITLE
Enable gRPC server reflection, upgrade gRPC to 1.44.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -86,9 +86,9 @@ http_archive(
 
 git_repository(
     name = "com_github_grpc_grpc",
-    commit = "dc78581af30da834b7b95572f109bf6c708686e0",
+    commit = "591d56e1300b6d11948e1b821efac785a295989c",  # 1.44.0
     remote = "https://github.com/grpc/grpc.git",
-    shallow_since = "1643221474 -0800"
+    shallow_since = "1644573434 +0100"
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")

--- a/src/tools/BUILD
+++ b/src/tools/BUILD
@@ -14,6 +14,7 @@ cc_library(
         "//src/proto:cc_proto",
         "@boost//:bind",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_github_grpc_grpc//:grpc++_reflection",
     ],
 )
 


### PR DESCRIPTION
This change enables gRPC server reflection on the codesearch server, which enables runtime introspection of available services by clients. One example motivation is to allow a protocol-aware health check that invokes gRPC methods by name (without otherwise having access to the associated server protos).

As it turns out, this is actually a regression fix; server reflection worked until e2dfb95b7c801d5d52a35d8a94fb32810e2f097b. I've been using this patch for several years but just realized I never proposed it upstream.

While I'm here, I've also bumped gRPC to 1.44.0, which is the latest version as of this writing.

Before:

```bash
$ grpc-cli ls localhost:9999 CodeSearch
Received an error when querying services endpoint.
Reflection request not implemented; is the ServerReflection service enabled?
```

After:

```bash
$ grpc-cli ls localhost:9999 CodeSearch
Info
Search
Reload
```