### PR TITLE
Flags to control gRPC server max send and receive message sizes

### DIFF
--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -54,6 +54,8 @@ DEFINE_string(grpc, "localhost:9999", "GRPC listener address");
 DEFINE_bool(reload_rpc, false, "Enable the Reload RPC");
 DEFINE_bool(hot_index_reload, false, "Enable automatic reloads when the index file changes");
 DEFINE_bool(reuseport, true, "Set SO_REUSEPORT to enable multiple concurrent server instances.");
+DEFINE_int32(max_recv_message_size, 0, "Maximum gRPC receive (inbound) message size in bytes");
+DEFINE_int32(max_send_message_size, 0, "Maximum gRPC send (outbound) message size in bytes");
 
 using namespace std;
 using namespace re2;
@@ -156,6 +158,12 @@ void listen_grpc(code_searcher *search, code_searcher *tags, const string& addr)
     builder.RegisterService(service.get());
     if (!FLAGS_reuseport) {
         builder.AddChannelArgument(GRPC_ARG_ALLOW_REUSEPORT, 0);
+    }
+    if (FLAGS_max_recv_message_size > 0) {
+        builder.AddChannelArgument(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, FLAGS_max_recv_message_size);
+    }
+    if (FLAGS_max_send_message_size > 0) {
+        builder.AddChannelArgument(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH, FLAGS_max_send_message_size);
     }
     std::unique_ptr<Server> server(builder.BuildAndStart());
     if (!server) {


### PR DESCRIPTION
This change proposes the addition of command line flags to `codesearch` to control the maximum receive/send message sizes used by the gRPC server. The two new flags are `--max_recv_message_size` and `--max_send_message_size`, which accept int32s as values.

The immediate motivation is to allow for very large query results that would otherwise exhaust the gRPC-default max outbound message size of 4 MB. It can also be used to set more aggressive circuit breakers than the gRPC defaults.

Verification of an overridden send threshold:

```bash
$ ./bazel-bin/src/tools/codesearch --load_index /tmp/index --grpc localhost:9999 --timeout 300000 --max_recv_message_size 4
```

```
# Error on the client after an example search request
# 4 bytes is too small to for the wire-serialized Query proto message.
Received message larger than max (15 vs. 4)
```

Verification of an overridden receive threshold:

```bash
$ ./bazel-bin/src/tools/codesearch --load_index /tmp/index --grpc localhost:9999 --timeout 300000 --max_send_message_size 1024
```

```
# Error on the client after an example search request with a very large set of results
Sent message larger than max (1481886 vs. 1024)
```