### PR TITLE
Move core logic of no-index to fetch-reindex

### DIFF
--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -25,6 +25,7 @@ var (
 	flagSkipMissing   = flag.Bool("skip-missing", false, "skip repositories where the specified revision is missing")
 	flagReloadBackend = flag.String("reload-backend", "", "Backend to send a Reload RPC to")
 	flagNumWorkers    = flag.Int("num-workers", 8, "Number of workers used to update repositories")
+	flagNoIndex       = flag.Bool("no-index", false, "Skip indexing after fetching")
 )
 
 func main() {
@@ -47,6 +48,11 @@ func main() {
 
 	if err := checkoutRepos(&cfg.Repositories); err != nil {
 		log.Fatalln(err.Error())
+	}
+
+	if *flagNoIndex {
+		log.Printf("Skipping indexing after fetching repos")
+		return
 	}
 
 	tmp := *flagIndexPath + ".tmp"

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -49,7 +49,7 @@ var (
 	flagDepth                   = flag.Int("depth", 0, "clone repository with specify --depth=N depth.")
 	flagSkipMissing             = flag.Bool("skip-missing", false, "skip repositories where the specified revision is missing")
 	flagMaxConcurrentGHRequests = flag.Int("max-concurrent-gh-requests", 1, "Applied per org/user. If fetching 2 orgs, you will have 2x{yourInput} network calls possible at a time")
-	flagNoIndex                 = flag.Bool("no-index", false, "Skip indexing after writing config")
+	flagNoIndex                 = flag.Bool("no-index", false, "Skip indexing after writing config and fetching")
 
 	flagRepos = stringList{}
 	flagOrgs  = stringList{}
@@ -140,10 +140,6 @@ func main() {
 	if err := writeConfig(config, configPath); err != nil {
 		log.Fatalln(err.Error())
 	}
-	if *flagNoIndex {
-		log.Printf("Skipping indexing after writing config")
-		return
-	}
 
 	index := flagIndexPath.Get().(string)
 
@@ -151,6 +147,7 @@ func main() {
 		"--out", index,
 		"--codesearch", *flagCodesearch,
 		"--num-workers", *flagNumRepoUpdateWorkers,
+		"--no-index", *flagNoIndex,
 	}
 	if *flagRevparse {
 		args = append(args, "--revparse")

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -147,7 +148,7 @@ func main() {
 		"--out", index,
 		"--codesearch", *flagCodesearch,
 		"--num-workers", *flagNumRepoUpdateWorkers,
-		"--no-index", *flagNoIndex,
+		"--no-index", strconv.FormatBool(*flagNoIndex),
 	}
 	if *flagRevparse {
 		args = append(args, "--revparse")


### PR DESCRIPTION
The original PR implemted the logic in github-reindex not realizing that the fetching of the repos was tightly
coupled to fetch-reindex. This means that, with the old implementation, you could run the config generation but nothing
would actually update. You would just have HEAD but the repos would still be outdated.

Ideally we could de-couple github operations from indexing operations and independently fetch/index, but saving a full refactor
the easiest solution is to pass the flag into fetch-reindex and exit after fetching repos