### PR TITLE
fix path for nginx conf in Docker image

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -5,5 +5,5 @@ ARG livegrep_version
 COPY ./builds/${livegrep_version}.tgz /livegrep.tgz
 
 RUN tar -C / -xzvf /livegrep.tgz
-COPY ./docker/nginx/nginx.conf /${livegrep_version}}/nginx.conf 
+COPY ./docker/nginx/nginx.conf /${livegrep_version}/nginx.conf
 RUN ln -nsf /${livegrep_version} /livegrep


### PR DESCRIPTION
Sorry I missed this! 

The extra `}` that snuck in was creating a seperate directory, like
```
livegrep/...
livegrep}/nginx.conf
```

So when nginx tried to start up with livegrep/nginx.conf it failed.