### PR TITLE
Show README file next to directory viewer

### DIFF
--- a/server/BUILD
+++ b/server/BUILD
@@ -40,6 +40,7 @@ go_test(
     srcs = [
         "query_test.go",
         "server_test.go",
+        "fileview_test.go",
     ],
     data = [
         "//web:htdocs",

--- a/server/fileview_test.go
+++ b/server/fileview_test.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestReadmeRegex(t *testing.T) {
+	cases := []struct {
+		in  string
+		out []string
+	}{
+		{
+			"README.md",
+			[]string{"README.md", "README", "md"},
+		},
+		{
+			"readme.md",
+			[]string{"readme.md", "readme", "md"},
+		},
+		{
+			"readme.rst",
+			[]string{"readme.rst", "readme", "rst"},
+		},
+		{
+			"readme.unknown",
+			nil,
+		},
+		{
+			"what.md",
+			nil,
+		},
+	}
+
+	for _, tc := range cases {
+		matches := supportedReadmeRegex.FindStringSubmatch(tc.in)
+		if !reflect.DeepEqual(tc.out, matches) {
+			got, _ := json.MarshalIndent(matches, "", "  ")
+			want, _ := json.MarshalIndent(tc.out, "", "  ")
+			t.Errorf("error parsing %q: expected:\n%s\ngot:\n%s",
+				tc.in, want, got)
+		}
+	}
+}

--- a/web/htdocs/assets/css/codesearch.css
+++ b/web/htdocs/assets/css/codesearch.css
@@ -419,6 +419,11 @@ a:hover {
     margin-top: 5em;
 }
 
+.file-viewer .dir-viewer-wrapper {
+    display: flex;
+    align-items: baseline;
+}
+
 .file-viewer .file-content {
     position: relative;
 }

--- a/web/templates/common/filecontent.html
+++ b/web/templates/common/filecontent.html
@@ -1,0 +1,18 @@
+{{define "filecontent"}}
+<div class="file-content">
+  <code id="source-code" class="code-pane language-{{.Language}}">{{.Content}}</code>
+  <!--
+  NOTE: The reason the line number links are after the code block above is because
+  they take a significant amount of time to render for large files. If we keep
+  them before the code block, we'll block the rendering of the important content until
+  the line numbers are done. Placing them after the code block and absolutely positioning them
+  to be rendered before seems to work well though.
+  -->
+  <div id="line-numbers" class="line-numbers hide-links" style="display:none">
+    {{range $index, $element := loop .LineCount}}
+      {{$lineNum := toLineNum $index}}
+      <a id="L{{$lineNum}}" href="#L{{$lineNum}}">{{$lineNum}}</a>
+    {{end}}
+  </div>
+</div>
+{{end}}

--- a/web/templates/fileview.html
+++ b/web/templates/fileview.html
@@ -47,32 +47,24 @@
 
   <div class="content-wrapper">
       {{with .DirContent}}
-      <ul class="file-list">
-          {{range $child := .Entries}}
-          <li class="file-list-entry{{if $child.IsDir}} is-directory{{end}}{{if $child.SymlinkTarget}} is-symlink{{end}}">
-            {{if $child.Path}}<a href="{{$child.Path}}">{{$child.Name}}{{if $child.IsDir}}/{{end}}</a>{{else}}{{$child.Name}}{{end}}
-            {{if .SymlinkTarget}}&rarr; (<span class="symlink-target">{{.SymlinkTarget}}</span>){{end}}
-          </li>
-          {{end}}
-      </ul>
-      {{end}}
-      {{with .FileContent}}
-      <div class="file-content">
-        <code id="source-code" class="code-pane language-{{.Language}}">{{.Content}}</code>
-        <!--
-        NOTE: The reason the line number links are after the code block above is because
-        they take a significant amount of time to render for large files. If we keep
-        them before the code block, we'll block the rendering of the important content until
-        the line numbers are done. Placing them after the code block and absolutely positioning them
-        to be rendered before seems to work well though.
-        -->
-        <div id="line-numbers" class="line-numbers hide-links" style="display:none">
-          {{range $index, $element := loop .LineCount}}
-            {{$lineNum := toLineNum $index}}
-            <a id="L{{$lineNum}}" href="#L{{$lineNum}}">{{$lineNum}}</a>
+        <div class="dir-viewer-wrapper">
+          <ul class="file-list">
+              {{range $child := .Entries}}
+              <li class="file-list-entry{{if $child.IsDir}} is-directory{{end}}{{if $child.SymlinkTarget}} is-symlink{{end}}">
+                {{if $child.Path}}<a href="{{$child.Path}}">{{$child.Name}}{{if $child.IsDir}}/{{end}}</a>{{else}}{{$child.Name}}{{end}}
+                {{if .SymlinkTarget}}&rarr; (<span class="symlink-target">{{.SymlinkTarget}}</span>){{end}}
+              </li>
+              {{end}}
+          </ul>
+          {{ with .ReadmeContent }}
+            <div style="width:80%;">
+              {{ template "filecontent" . }}
+            </div>
           {{end}}
         </div>
-      </div>
+      {{end}}
+      {{with .FileContent}}
+        {{ template "filecontent" . }}
       {{end}}
   </div>
 


### PR DESCRIPTION
Small change to automatically show README file's next to the directory viewer, if they exist. 

Decided to have this happen for any directory, in case a repo has README files in subdirectories. I restricted the possible readme extensions to the set that GitHub accepts (https://github.com/github/markup), which may not be necessary but eh.

Here's what this looks like when a readme file is present. 
<img width="1788" alt="Screen Shot 2022-03-17 at 10 54 14 PM" src="https://user-images.githubusercontent.com/23644345/158945799-f9525a7f-b60b-45f0-a918-aa2c5e4f7b92.png">

And if no readme file it looks the same as before.
<img width="665" alt="Screen Shot 2022-03-17 at 10 59 02 PM" src="https://user-images.githubusercontent.com/23644345/158946019-9ec372b5-6a6c-4217-9d2a-4edbac575019.png">

