### PR TITLE
Fix stack overflow in inotify-based reload watcher routine

### DIFF
--- a/src/lib/fs_linux.cc
+++ b/src/lib/fs_linux.cc
@@ -11,6 +11,8 @@
 #include <sys/inotify.h>
 #include <unistd.h>
 
+const ssize_t max_event_len = sizeof(struct inotify_event) + NAME_MAX + 1;
+
 namespace {
     int fd = -1;
     int wd = -1;
@@ -29,8 +31,8 @@ fswatcher::~fswatcher() {
 }
 
 bool fswatcher::wait_for_event() {
-    struct inotify_event event;
-    int n = 0;
+    char buf[max_event_len];
+    ssize_t n = 0;
 
     if (fd == -1 || wd == -1) {
         return false;
@@ -38,7 +40,7 @@ bool fswatcher::wait_for_event() {
 
     // The read syscall is blocking; it returns after one eligible event (i.e., matching the mask) is received.
     while (n <= 0) {
-        n = read(fd, &event, sizeof(struct inotify_event) + NAME_MAX + 1);
+        n = read(fd, &buf, max_event_len);
     }
 
     return true;


### PR DESCRIPTION
While working on the unrelated patch described https://github.com/livegrep/livegrep/issues/331#issuecomment-1101043856 I found a stack overflow bug in the inotify-based index reload watcher.

A `read` on the inotify fd returns a `struct inotify_event`, plus the name of the affected file, followed by a null termination character. The previous logic allowed a full read of all this data, but into only a container of size `struct inotify_event`. This change allocates a buffer with the maximum possible read length to avoid stack corruption.

To reproduce:

Build an index `/tmp/index`, and load it with:

```
$ ./bazel-bin/src/tools/codesearch --load_index /tmp/index --hot_index_reload
```

```
$ touch /tmp/index
```

Observe stack overflow:

```
Serving...
*** stack smashing detected ***: terminated
Aborted (core dumped)
```

With this patch:

```
Serving...
Detected change to index file; reloading...
Serving...
Detected change to index file; reloading...
Serving...
```