### PR TITLE
Score and rank git files before indexing

### DIFF
--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -81,7 +81,6 @@ struct indexed_tree {
 };
 
 struct indexed_file {
-    string repopath;
     const indexed_tree *tree;
     string path;
     file_contents *content;

--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -81,6 +81,7 @@ struct indexed_tree {
 };
 
 struct indexed_file {
+    string repopath;
     const indexed_tree *tree;
     string path;
     file_contents *content;

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -41,10 +41,10 @@ git_indexer::~git_indexer() {
 
 // Used to get the next index of a repo a thread should focus on
 int git_indexer::get_next_repo_idx() {
-    if (next_repo_to_process_idx_ == repositories_to_index_length_) {
+    if (next_repo_to_process_idx_.load() == repositories_to_index_length_) {
         return -1;
     }
-    return next_repo_to_process_idx_++;
+    return next_repo_to_process_idx_.fetch_add(1, std::memory_order_relaxed);
 }
 
 void git_indexer::print_last_git_err_and_exit(int err) {

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -142,8 +142,12 @@ void git_indexer::begin_indexing() {
     index_files();
 }
 
-bool compareFiles(const std::unique_ptr<pre_indexed_file>& a, const std::unique_ptr<pre_indexed_file>& b) {
+bool compareFilesByScore(const std::unique_ptr<pre_indexed_file>& a, const std::unique_ptr<pre_indexed_file>& b) {
     return a->score > b->score;
+}
+
+bool compareFilesByTree(const std::unique_ptr<pre_indexed_file>& a, const std::unique_ptr<pre_indexed_file>& b) {
+    return a->tree->name < b->tree->name;
 }
 
 // sorts `files_to_index_` based on score. This way, the lowest scoring files
@@ -156,8 +160,12 @@ bool compareFiles(const std::unique_ptr<pre_indexed_file>& a, const std::unique_
 // walks `files_to_index_`, looks up the repo & blob combination for each file
 // and then calls `cs->index_file` to actually index the file.
 void git_indexer::index_files() {
-    fprintf(stderr, "sorting files_to_index_... [%lu]\n", files_to_index_.size());
-    std::stable_sort(files_to_index_.begin(), files_to_index_.end(), compareFiles);
+    fprintf(stderr, "sorting files_to_index_ by tree... [%lu]\n", files_to_index_.size());
+    std::stable_sort(files_to_index_.begin(), files_to_index_.end(), compareFilesByTree);
+    fprintf(stderr, "  done\n");
+
+    fprintf(stderr, "sorting files_to_index_ by score... [%lu]\n", files_to_index_.size());
+    std::stable_sort(files_to_index_.begin(), files_to_index_.end(), compareFilesByScore);
     fprintf(stderr, "  done\n");
 
     /* fprintf(stderr, "walking files_to_index_ ...\n"); */

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -206,12 +206,12 @@ void git_indexer::index_files() {
 }
 
 void git_indexer::walk(git_repository *curr_repo,
-        std::string ref, 
-        std::string repopath, 
-        std::string name,
+        const std::string& ref,
+        const std::string& repopath,
+        const std::string& name,
         Metadata metadata,
         bool walk_submodules,
-        std::string submodule_prefix) {
+        const std::string& submodule_prefix) {
     smart_object<git_commit> commit;
     smart_object<git_tree> tree;
     if (0 != git_revparse_single(commit, curr_repo, (ref + "^0").c_str())) {
@@ -229,11 +229,11 @@ void git_indexer::walk(git_repository *curr_repo,
 }
 
 
-void git_indexer::walk_tree(std::string pfx,
-                            std::string order,
-                            std::string repopath,
+void git_indexer::walk_tree(const std::string& pfx,
+                            const std::string& order,
+                            const std::string& repopath,
                             bool walk_submodules,
-                            std::string submodule_prefix,
+                            const std::string& submodule_prefix,
                             const indexed_tree *idx_tree,
                             git_tree *tree,
                             git_repository *curr_repo,

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -156,21 +156,12 @@ void git_indexer::index_files() {
     for (auto it = files_to_index_.begin(); it != files_to_index_.end(); ++it) {
         auto file = it->get();
 
-        const char *repopath = file->repopath.c_str();
-        char buf[GIT_OID_HEXSZ + 1];
-         git_oid_tostr(buf, sizeof(buf), file->oid.get());
-
-        fprintf(stderr, "indexing %s/%s - %s\n", repopath, file->path.c_str(), buf);
-
-        /* git_oid blob_id; */
-        /* int err = git_oid_fromstr(&blob_id, file->id.c_str()); */
-
-        /* if (err < 0) { */
-        /*     print_last_git_err_and_exit(err); */
-        /* } */
-
-        /* const git_oid blob_id_static = static_cast<git_oid>(blob_id); */
         git_blob *blob;
+        // TODO: Test and ensure that duplicate files across repos have unique
+        // oid's. I believe the odds of duplicate id's, even across multiple
+        // files is extremely low
+        // However, since we have "all" repos open at the same time, what
+        // happens to git_blob_lookup if there are duplicated oid's present?
         int err = git_blob_lookup(&blob, file->repo, file->oid.get());
 
         if (err < 0) {
@@ -255,14 +246,14 @@ void git_indexer::walk_tree(const string& pfx,
         if (git_tree_entry_type(*it) == GIT_OBJ_TREE) {
             walk_tree(path + "/", "", repopath, walk_submodules, submodule_prefix, idx_tree, obj, curr_repo, results);
         } else if (git_tree_entry_type(*it) == GIT_OBJ_BLOB) {
-            const git_oid* blob_id = git_blob_id(obj);
-            char blob_id_str[GIT_OID_HEXSZ + 1];
-            git_oid_tostr(blob_id_str, GIT_OID_HEXSZ + 1, blob_id);
+            /* const git_oid* blob_id = git_blob_id(obj); */
+            /* char blob_id_str[GIT_OID_HEXSZ + 1]; */
+            /* git_oid_tostr(blob_id_str, GIT_OID_HEXSZ + 1, blob_id); */
 
             const string full_path = submodule_prefix + path;
             auto file = std::make_unique<pre_indexed_file>();
 
-            file->id = string(blob_id_str);
+            /* file->id = string(blob_id_str); */
             file->tree = idx_tree;
             file->repopath = repopath;
             file->path = path;
@@ -274,7 +265,7 @@ void git_indexer::walk_tree(const string& pfx,
             auto iod = std::make_unique<git_oid>(copy);
             file->oid = std::move(iod);
 
-            fprintf(stderr, "indexing %s/%s - %s\n", repopath.c_str(), file->path.c_str(), blob_id_str);
+            /* fprintf(stderr, "indexing %s/%s - %s\n", repopath.c_str(), file->path.c_str(), blob_id_str); */
             /* if (!files_to_index_local.get()) { */
             /*     files_to_index_local.put(new vector<pre_indexed_file>()); */
             /*     files_to_index_local.get()->reserve(100); */

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -242,21 +242,27 @@ void git_indexer::begin_indexing() {
     /* } */
 
     fprintf(stderr, "waiting for threads\n");
-     trees_to_walk_.close();
-     fq_.close();
+
+    // we can close the trees, since we only add to trees_to_walk_ at the
+    // root/unordered level
+    trees_to_walk_.close();
     for (long i = 0; i < num_threads; ++i) {
         threads_[i].join();
     }
+
+    // but we can't close the fq_ until all trees have been processed
+    fq_.close();
     auto stop = high_resolution_clock::now();
     auto duration = duration_cast<milliseconds>(stop - start);
     cout << "took: " << duration.count() << " milliseconds to process_repos" << endl;
-     pre_indexed_file *p;
+    /* exit(0); */
+    pre_indexed_file *p;
 
 
-        while (fq_.pop(&p)) {
-            /* fprintf(stderr, "pushing back some stuff\n"); */
-            files_to_index_.push_back(p);
-        }
+    while (fq_.pop(&p)) {
+        /* fprintf(stderr, "pushing back some stuff\n"); */
+        files_to_index_.push_back(p);
+    }
     fprintf(stderr, "done waiting\n");
 
     /* exit(0); */

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -34,13 +34,11 @@ git_indexer::~git_indexer() {
 
 void git_indexer::begin_indexing() {
 
-    // The below will populate files_to_index_
+    // populate files_to_index_
     for (auto &repo : repositories_to_index_) {
-        /* repopath_ = repo.path(); */
         const char *repopath = repo.path().c_str();
 
         fprintf(stderr, "walking repo: %s\n", repopath);
-        // if repo has already been set AND it's not the same as this one
         git_repository *curr_repo = NULL;
 
         int err = git_repository_open(&curr_repo, repopath);
@@ -84,8 +82,6 @@ void git_indexer::index_files() {
             git_repository_open(&curr_repo, repopath);
         }
 
-        /* fprintf(stderr, "%s/%s. id: %s \n", repopath, file->path.c_str(), file->id.c_str()); */ 
-
         git_oid blob_id;
         int err = git_oid_fromstr(&blob_id, file->id.c_str());
 
@@ -98,15 +94,6 @@ void git_indexer::index_files() {
         const git_oid blob_id_static = static_cast<git_oid>(blob_id);
 
 
-        /* fprintf(stderr, "open at: %s\n", git_repository_path(curr_repo)); */
-        /* fprintf(stderr, "repopath: %s\n", repopath); */
-        /* string repo_path = string(git_repository_path(repo_)); */
-        /* fprintf(stderr, "equal: %d\n", strcmp(repo_path + strlen(repo_path) - (strlen(file->repopath) + 1), file->repopath + "/") == 0); */
-
-        
-
-        /* fprintf(stderr, "_repo opened at path: %s\n", git_repository_path(curr_repo)); */
-
         // now that the repo is open
         git_blob *blob;
 
@@ -117,9 +104,6 @@ void git_indexer::index_files() {
             printf("Error %d/%d: %s\n", err, e->klass, e->message);
             exit(err);
         }
-
-
-        /* fprintf(stderr, "blob looked up, (theoretically). Owner: %s\n", git_repository_path(git_blob_owner(blob))); */
 
         const char *data = static_cast<const char*>(git_blob_rawcontent(blob));
 
@@ -206,18 +190,8 @@ void git_indexer::walk_tree(const string& pfx,
             file->path =  full_path;
             file->score = score_file(full_path);
 
-            // I need to copy the oid back and forth, otherwise I run into that
-            // indeterminate behavior thats described
-            
-            /* fprintf(stderr, "%s/%s -> %s\n", repopath.c_str(), full_path.c_str(), git_oid_tostr_s(blob_id)); */
-            /* fprintf(stderr, "id_test: %s\n", file->id.c_str()); */
-            /* fprintf(stderr, "id_test2 raw 20 bytes: [%s]\n", file->id_test2); */
-
             files_to_index_.push_back(std::move(file));
 
-
-            /* const char *data = static_cast<const char*>(git_blob_rawcontent(obj)); */
-            /* cs_->index_file(idx_tree_, submodule_prefix_ + path, StringPiece(data, git_blob_rawsize(obj))); */
         } else if (git_tree_entry_type(*it) == GIT_OBJ_COMMIT) {
             // Submodule
             if (!walk_submodules) {
@@ -234,14 +208,9 @@ void git_indexer::walk_tree(const string& pfx,
             string new_submodule_prefix = submodule_prefix + path + "/";
             Metadata meta;
 
-            /* git_indexer sub_indexer(cs_, sub_repopath, string(sub_name), meta, walk_submodules_); */
-            /* sub_indexer.submodule_prefix_ = submodule_prefix_ + path + "/"; */
-
             const git_oid* rev = git_tree_entry_id(*it);
             char revstr[GIT_OID_HEXSZ + 1];
             git_oid_tostr(revstr, GIT_OID_HEXSZ + 1, rev);
-
-            /* sub_indexer.walk(string(revstr)); */
 
             // Open the submodule repo
             git_repository *sub_repo;

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -20,7 +20,7 @@ DEFINE_bool(revparse, false, "Display parsed revisions, rather than as-provided"
 
 git_indexer::git_indexer(code_searcher *cs,
                          const google::protobuf::RepeatedPtrField<RepoSpec>& repositories)
-    : cs_(cs), repositories_to_index_(repositories), repositories_to_index_length_(repositories.size()) {
+    : cs_(cs), repositories_to_index_(repositories), repositories_to_index_length_(repositories.size()), trees_to_walk_(), fq_() {
     int err;
     if ((err = git_libgit2_init()) < 0)
         die("git_libgit2_init: %s", giterr_last()->message);
@@ -53,21 +53,132 @@ void git_indexer::print_last_git_err_and_exit(int err) {
     exit(1);
 }
 
-void git_indexer::process_repos(int estimatedReposToProcess, threadsafe_progress_indicator *tpi) {
-    int idx_to_process = get_next_repo_idx();
-    std::vector<git_repository *> open_git_repos_local;
-    std::vector<std::unique_ptr<pre_indexed_file>> files_to_index_local;
+/* void git_indexer::process_repos(int estimatedReposToProcess, threadsafe_progress_indicator *tpi) { */
+/*     int idx_to_process = get_next_repo_idx(); */
+/*     std::vector<git_repository *> open_git_repos_local; */
+/*     std::vector<std::unique_ptr<pre_indexed_file>> files_to_index_local; */
 
-    open_git_repos_local.reserve(estimatedReposToProcess);
-    files_to_index_local.reserve(estimatedReposToProcess * 100);
+/*     open_git_repos_local.reserve(estimatedReposToProcess); */
+/*     files_to_index_local.reserve(estimatedReposToProcess * 100); */
 
-    while (idx_to_process >= 0) {
-        /* fprintf(stderr, "going to process: %d\n", idx_to_process); */
-        /* auto start = high_resolution_clock::now(); */
-        const auto &repo = repositories_to_index_[idx_to_process];
+/*     while (idx_to_process >= 0) { */
+/*         /1* fprintf(stderr, "going to process: %d\n", idx_to_process); *1/ */
+/*         /1* auto start = high_resolution_clock::now(); *1/ */
+/*         const auto &repo = repositories_to_index_[idx_to_process]; */
+/*         const char *repopath = repo.path().c_str(); */
+
+/*         /1* fprintf(stderr, "walking repo: %s\n", repopath); *1/ */
+/*         git_repository *curr_repo = NULL; */
+
+/*         // Is it safe to assume these are bare repos (or the mirror clones) */
+/*         // that we create?. If so, we can use git_repository_open_bare */
+/*         int err = git_repository_open_bare(&curr_repo, repopath); */
+/*         if (err < 0) { */
+/*             print_last_git_err_and_exit(err); */
+/*         } */
+
+/*         open_git_repos_local.push_back(curr_repo); */
+
+/*         /1* for (auto &rev : repo.revisions()) { *1/ */
+/*             /1* fprintf(stderr, "walking %s at %s \n", repopath, rev.c_str()); *1/ */
+/*             /1* walk(curr_repo, rev, repo.path(), repo.name(), repo.metadata(), repo.walk_submodules(), "", files_to_index_local); *1/ */
+/*             /1* fprintf(stderr, "done walking %s at %s\n", repopath, rev.c_str()); *1/ */
+/*             /1* tpi->tick(); *1/ */
+/*         /1* } *1/ */
+/*         /1* auto stop = high_resolution_clock::now(); *1/ */
+/*         /1* auto duration = duration_cast<seconds>(stop - start); *1/ */
+/*         /1* cout << "took: " << duration.count() << " seconds to process_repos" << endl; *1/ */
+
+/*         idx_to_process = get_next_repo_idx(); */
+/*     } */
+
+/*     std::lock_guard<std::mutex> guard(files_mutex_); */
+/*     files_to_index_.insert(files_to_index_.end(), std::make_move_iterator(files_to_index_local.begin()), std::make_move_iterator(files_to_index_local.end())); */
+/*     open_git_repos_.insert(open_git_repos_.end(), open_git_repos_local.begin(), open_git_repos_local.end()); */
+/* } */
+void git_indexer::process_trees(int thread_id) {
+    fprintf(stderr, "thread %d listening\n", thread_id);
+    tree_to_walk *d;
+
+    while (trees_to_walk_.pop(&d)) {
+        // got a t with
+        /* fprintf(stderr, "thread[%d] popped an elem off the stack\n", thread_id); */
+        /* std::cout << t; */
+
+        /* std::cout << "Name: " << d->name << " repopath: " << d->repopath << std::endl; */
+
+        /* std::cout << "repopath: " << d->repopath << std::endl; */
+        fprintf(stderr, "thread[%d]: %s/%s\n", thread_id, d->repopath.c_str(), d->prefix.c_str());
+
+        /* std::cout << "Id addr: " << tree << std::endl; */
+              /* << "walk_submodules: " << tree->walk_submodules << std::endl */
+              /* << "submodule_prefix: " << tree->submodule_prefix << std::endl */
+              /* << "idx_tree.name " << tree->idx_tree->name << std::endl; */
+        /* fprintf(stderr, "[%d]: walk_tree('%s','%s','%s')\n", thread_id, tree->prefix.c_str(), tree->order.c_str(), tree->repopath.c_str()); */
+        walk_tree(d->prefix, d->order, d->repopath, d->walk_submodules, 
+                d->submodule_prefix, d->idx_tree, d->tree, d->repo, 1);
+    }
+}
+
+/* void git_indexer::process_trees(int thread_id) { */
+/*     fprintf(stderr, "thread %d listening\n", thread_id); */
+/*     tree_to_walk *tree; */
+
+/*     while (trees_to_walk_.pop(&tree)) { */
+/*         // got a t with */
+/*         fprintf(stderr, "thread[%d] popped an elem off the stack\n", thread_id); */
+/*         /1* std::cout << t; *1/ */
+/*         std::cout << "Id: " << tree->id << std::endl */ 
+/*               << "Prefix: " << tree->prefix << std::endl */
+/*               << "Order: " << tree->order << std::endl */
+/*               << "repopath: " << tree->repopath << std::endl;; */
+/*         fprintf(stderr, "\n"); */
+/*               /1* << "walk_submodules: " << tree->walk_submodules << std::endl *1/ */
+/*               /1* << "submodule_prefix: " << tree->submodule_prefix << std::endl *1/ */
+/*               /1* << "idx_tree.name " << tree->idx_tree->name << std::endl; *1/ */
+/*         /1* fprintf(stderr, "[%d]: walk_tree('%s','%s','%s')\n", thread_id, tree->prefix.c_str(), tree->order.c_str(), tree->repopath.c_str()); *1/ */
+/*         walk_tree(tree->prefix, tree->order, tree->repopath, tree->walk_submodules, */ 
+/*                 tree->submodule_prefix, tree->idx_tree, tree->tree, tree->repo, 1); */
+/*     } */
+/* } */
+
+void git_indexer::begin_indexing() {
+
+    // min_per_thread will require tweaking. For example, even with only
+    // 2 repos, would it not be worth it to spin up two threads (if available)?
+    // Or would the overhead of the thread creation far outweigh the single-core
+    // performance for just a few repos.
+    
+    /* unsigned long const length = repositories_to_index_.size(); */
+    /* unsigned long const min_per_thread = 16; */ 
+    /* unsigned long const max_threads = */ 
+    /*     (length + min_per_thread - 1)/min_per_thread; */
+    /* unsigned long const hardware_threads = std::thread::hardware_concurrency(); */
+    unsigned long const num_threads = std::thread::hardware_concurrency();
+
+    /* fprintf(stderr, "length=%lu min_per_thread=%lu max_threads=%lu hardware_threads=%lu num_threads=%lu\n", length, min_per_thread, max_threads, hardware_threads, num_threads); */
+    /* std::vector<git_repository *> open_git_repos_local; */
+    /* std::vector<std::unique_ptr<pre_indexed_file>> files_to_index_local; */
+
+    /* open_git_repos_local.reserve(estimatedReposToProcess); */
+    /* files_to_index_local.reserve(estimatedReposToProcess * 100); */
+
+    // we should spin up n number of threads, that listen to a queue of trees_to_walks
+    // then walk_tree adds items to the queue whenenver it hits a tree
+    // Unfortunately that means we have n producers and n consumers
+
+    // A single repo at a time
+    /* int idx = 0; */
+
+    threads_.reserve(num_threads - 1);
+    for (long i = 0; i < num_threads; ++i) {
+        threads_.emplace_back(&git_indexer::process_trees, this, i);
+    }
+    threadsafe_progress_indicator tpi(repositories_to_index_length_, "Walking repos...", "Done");
+     for (const auto &repo : repositories_to_index_) {
         const char *repopath = repo.path().c_str();
 
-        /* fprintf(stderr, "walking repo: %s\n", repopath); */
+        fprintf(stderr, "walking repo: %s\n", repopath);
         git_repository *curr_repo = NULL;
 
         // Is it safe to assume these are bare repos (or the mirror clones)
@@ -77,66 +188,76 @@ void git_indexer::process_repos(int estimatedReposToProcess, threadsafe_progress
             print_last_git_err_and_exit(err);
         }
 
-        open_git_repos_local.push_back(curr_repo);
+        open_git_repos_.push_back(curr_repo);
 
         for (auto &rev : repo.revisions()) {
             /* fprintf(stderr, "walking %s at %s \n", repopath, rev.c_str()); */
-            walk(curr_repo, rev, repo.path(), repo.name(), repo.metadata(), repo.walk_submodules(), "", files_to_index_local);
+            walk(curr_repo, rev, repo.path(), repo.name(), repo.metadata(), repo.walk_submodules(), "");
+            /* tree_to_walk t{ */
+            /*     std::rand(), */
+            /*     "/", */
+            /*     "", */
+            /*     repo.path(), */
+            /*     false, */
+            /*     "", */
+            /* }; */
+            /* tree_to_walk t{}; */
+            /* t.repopath = repopath; */
+            /* t.prefix = path + "/"; */
+            
+        /* fprintf(stderr, "t is initially ----\n"); */
+        /* fprintf(stderr, "repopath.size(): %lu\n", repopath.size()); */
+        /* std::cout << "Prefix: " << t.prefix << std::endl */
+        /*       << "Order: " << t.order << std::endl */
+        /*       << "repopath: " << t.repopath << std::endl */
+        /*       << "walk_submodules: " << t.walk_submodules << std::endl */
+        /*       << "submodule_prefix: " << t.submodule_prefix << std::endl */
+        /*       << "idx_tree.name " << t.idx_tree->name << std::endl; */
+            /* fprintf(stderr, "about to push to trees_to_walk_ id: %d\n", t.id); */
+            /* trees_to_walk_.push(&t); */
             /* fprintf(stderr, "done walking %s at %s\n", repopath, rev.c_str()); */
-            tpi->tick();
         }
-        /* auto stop = high_resolution_clock::now(); */
-        /* auto duration = duration_cast<seconds>(stop - start); */
-        /* cout << "took: " << duration.count() << " seconds to process_repos" << endl; */
+        /* tpi.tick(); */
+     }
 
-        idx_to_process = get_next_repo_idx();
-    }
-
-    std::lock_guard<std::mutex> guard(files_mutex_);
-    files_to_index_.insert(files_to_index_.end(), std::make_move_iterator(files_to_index_local.begin()), std::make_move_iterator(files_to_index_local.end()));
-    open_git_repos_.insert(open_git_repos_.end(), open_git_repos_local.begin(), open_git_repos_local.end());
-}
+     // ahhh, this may have to be rethought. When we're done walking repos
+     // it doesn't mean that all of the subdirectories have been traversed
+     // So if we close this, we may run into problems.
+     trees_to_walk_.close();
+     fq_.close();
 
 
-void git_indexer::begin_indexing() {
 
-    // min_per_thread will require tweaking. For example, even with only
-    // 2 repos, would it not be worth it to spin up two threads (if available)?
-    // Or would the overhead of the thread creation far outweigh the single-core
-    // performance for just a few repos.
-    
-    unsigned long const length = repositories_to_index_.size();
-    unsigned long const min_per_thread = 16; 
-    unsigned long const max_threads = 
-        (length + min_per_thread - 1)/min_per_thread;
-    unsigned long const hardware_threads = std::thread::hardware_concurrency();
-    unsigned long const num_threads = std::min(hardware_threads!=0?hardware_threads:2, max_threads);
+    /* if (length < 2 * min_per_thread) { */
+    /*     fprintf(stderr, "Not going to create any new threads.\n"); */
+    /*     process_repos(length, &tpi); */
+    /*     index_files(); */
+    /*     return; */
+    /* } */
 
-    fprintf(stderr, "length=%lu min_per_thread=%lu max_threads=%lu hardware_threads=%lu num_threads=%lu\n", length, min_per_thread, max_threads, hardware_threads, num_threads);
+    /* int estimatedReposPerThread = length / num_threads; */
+    /* threads_.reserve(num_threads - 1); */
+    /* auto start = high_resolution_clock::now(); */
+    /* for (long i = 0; i < num_threads; ++i) { */
+    /*     threads_.emplace_back(&git_indexer::process_repos, this, estimatedReposPerThread, &tpi); */
+    /* } */
 
-    threadsafe_progress_indicator tpi(length, "Walking repos...", "Done");
-
-    if (length < 2 * min_per_thread) {
-        fprintf(stderr, "Not going to create any new threads.\n");
-        process_repos(length, &tpi);
-        index_files();
-        return;
-    }
-
-    int estimatedReposPerThread = length / num_threads;
-    threads_.reserve(num_threads - 1);
-    auto start = high_resolution_clock::now();
-    for (long i = 0; i < num_threads; ++i) {
-        threads_.emplace_back(&git_indexer::process_repos, this, estimatedReposPerThread, &tpi);
-    }
-
+    fprintf(stderr, "waiting for threads\n");
     for (long i = 0; i < num_threads; ++i) {
         threads_[i].join();
     }
+     pre_indexed_file *p;
 
-    auto stop = high_resolution_clock::now();
-    auto duration = duration_cast<milliseconds>(stop - start);
-    cout << "took: " << duration.count() << " milliseconds to process_repos" << endl;
+
+        while (fq_.pop(&p)) {
+            /* fprintf(stderr, "pushing back some stuff\n"); */
+            files_to_index_.push_back(p);
+        }
+    fprintf(stderr, "done waiting\n");
+
+    /* auto stop = high_resolution_clock::now(); */
+    /* auto duration = duration_cast<milliseconds>(stop - start); */
+    /* cout << "took: " << duration.count() << " milliseconds to process_repos" << endl; */
     /* exit(0); */
 
     index_files();
@@ -160,18 +281,20 @@ bool compareFilesByTree(const std::unique_ptr<pre_indexed_file>& a, const std::u
 // walks `files_to_index_`, looks up the repo & blob combination for each file
 // and then calls `cs->index_file` to actually index the file.
 void git_indexer::index_files() {
-    fprintf(stderr, "sorting files_to_index_ by tree... [%lu]\n", files_to_index_.size());
-    std::stable_sort(files_to_index_.begin(), files_to_index_.end(), compareFilesByTree);
-    fprintf(stderr, "  done\n");
+    /* fprintf(stderr, "sorting files_to_index_ by tree... [%lu]\n", files_to_index_.size()); */
+    /* std::stable_sort(files_to_index_.begin(), files_to_index_.end(), compareFilesByTree); */
+    /* fprintf(stderr, "  done\n"); */
 
-    fprintf(stderr, "sorting files_to_index_ by score... [%lu]\n", files_to_index_.size());
-    std::stable_sort(files_to_index_.begin(), files_to_index_.end(), compareFilesByScore);
-    fprintf(stderr, "  done\n");
+    /* fprintf(stderr, "sorting files_to_index_ by score... [%lu]\n", files_to_index_.size()); */
+    /* std::stable_sort(files_to_index_.begin(), files_to_index_.end(), compareFilesByScore); */
+    /* fprintf(stderr, "  done\n"); */
 
     /* fprintf(stderr, "walking files_to_index_ ...\n"); */
     threadsafe_progress_indicator tpi(files_to_index_.size(), "Indexing files_to_index_...", "Done");
     for (auto it = files_to_index_.begin(); it != files_to_index_.end(); ++it) {
-        auto file = it->get();
+        auto file = *it;
+
+        fprintf(stderr, "indexing: %s/%s\n", file->repopath.c_str(), file->path.c_str());
 
         git_blob *blob;
         int err = git_blob_lookup(&blob, file->repo, file->oid);
@@ -189,13 +312,12 @@ void git_indexer::index_files() {
 }
 
 void git_indexer::walk(git_repository *curr_repo,
-        const string& ref, 
-        const string& repopath, 
-        const string& name,
+        std::string ref, 
+        std::string repopath, 
+        std::string name,
         Metadata metadata,
         bool walk_submodules,
-        const string& submodule_prefix,
-        std::vector<std::unique_ptr<pre_indexed_file>>& results) {
+        std::string submodule_prefix) {
     smart_object<git_commit> commit;
     smart_object<git_tree> tree;
     if (0 != git_revparse_single(commit, curr_repo, (ref + "^0").c_str())) {
@@ -210,25 +332,28 @@ void git_indexer::walk(git_repository *curr_repo,
         strdup(git_oid_tostr(oidstr, sizeof(oidstr), git_commit_id(commit))) : ref;
 
     const indexed_tree *idx_tree = cs_->open_tree(name, metadata, version);
-    walk_tree("", FLAGS_order_root, repopath, walk_submodules, submodule_prefix, idx_tree, tree, curr_repo, results);
+    walk_tree("", FLAGS_order_root, repopath, walk_submodules, submodule_prefix, idx_tree, tree, curr_repo, 0);
 }
 
 
-void git_indexer::walk_tree(const string& pfx,
-                            const string& order,
-                            const string& repopath,
+void git_indexer::walk_tree(std::string pfx,
+                            std::string order,
+                            std::string repopath,
                             bool walk_submodules,
-                            const string& submodule_prefix,
+                            std::string submodule_prefix,
                             const indexed_tree *idx_tree,
                             git_tree *tree,
                             git_repository *curr_repo,
-                            std::vector<std::unique_ptr<pre_indexed_file>>& results) {
-    /* fprintf(stderr, "preparing to walk_tree for %s with prefix: %s \n", repopath.c_str(), pfx.c_str()); */
+                            int depth) {
+    /* fprintf(stderr, "[%d] preparing to walk_tree for %s with prefix: %s \n", depth, repopath.c_str(), pfx.c_str()); */
+    /* if (depth == 1) { */
+    /*     return; */
+    /* } */
     map<string, const git_tree_entry *> root;
     vector<const git_tree_entry *> ordered;
     int entries = git_tree_entrycount(tree);
     /* fprintf(stderr, "repo: %s has %d entries\n", repopath.c_str(), entries); */
-    for (int i = 0; i < entries; ++i) {
+    for (int i = 0; i < entries; ++i) { // TODO: we could divide each of these repos up by threads
         const git_tree_entry *ent = git_tree_entry_byindex(tree, i);
         root[git_tree_entry_name(ent)] = ent;
     }
@@ -255,22 +380,76 @@ void git_indexer::walk_tree(const string& pfx,
         /* fprintf(stderr, "walking obj with path: %s/%s\n", repopath.c_str(), path.c_str()); */
 
         if (git_tree_entry_type(*it) == GIT_OBJ_TREE) {
-            walk_tree(path + "/", "", repopath, walk_submodules, submodule_prefix, idx_tree, obj, curr_repo, results);
+            /* fprintf(stderr, "entry is git_tree\n"); */
+            // But more likely, when depth == 1, we could add these to a thread
+            // pool. In that way, a repo could "potentially" be walked by 10
+            // threads at a time
+            /* fprintf(stderr, "going to add repopath with %s\n", repopath.c_str()); */
+
+            tree_to_walk *t = new tree_to_walk;
+            t->prefix = path + "/";
+            t->order = "";
+            t->repopath = repopath;
+            t->walk_submodules = walk_submodules;
+            t->submodule_prefix = submodule_prefix;
+            t->idx_tree = idx_tree;
+            t->tree = obj;
+            t->repo = curr_repo;
+
+
+            trees_to_walk_.push(t);
+
+            /* auto tree = std::make_unique<tree_to_walk>(); */
+            /* tree_to_walk t{ */
+            /*     std::rand(), */
+            /*     path + "/", */
+            /*     "", */
+            /*     repopath + "/", */
+            /*     walk_submodules, */
+            /*     submodule_prefix, */
+            /*     idx_tree, */
+            /*     obj, */
+            /*     curr_repo, */
+            /* }; */
+            /* tree_to_walk t{}; */
+            /* t.repopath = repopath; */
+            /* t.prefix = path + "/"; */
+            
+        /* fprintf(stderr, "t is initially ----\n"); */
+        /* fprintf(stderr, "repopath.size(): %lu\n", repopath.size()); */
+        /* std::cout << "Prefix: " << t.prefix << std::endl */
+        /*       << "Order: " << t.order << std::endl */
+        /*       << "repopath: " << t.repopath << std::endl */
+        /*       << "walk_submodules: " << t.walk_submodules << std::endl */
+        /*       << "submodule_prefix: " << t.submodule_prefix << std::endl */
+        /*       << "idx_tree.name " << t.idx_tree->name << std::endl; */
+            /* fprintf(stderr, "about to push to trees_to_walk_ id: %d\n", t.id); */
+            /* trees_to_walk_.push(&t); */
+
+            /* dummy *d = new dummy; */
+            /* d->name = "hello = " + repopath; */
+            /* d->repopath = repopath; */
+            /* trees_to_walk_.push(d); */
+
+            /* walk_tree(path + "/", "", repopath, walk_submodules, submodule_prefix, idx_tree, obj, curr_repo, results); */
         } else if (git_tree_entry_type(*it) == GIT_OBJ_BLOB) {
+            /* fprintf(stderr, "entry is blob\n"); */
 
             const string full_path = submodule_prefix + path;
 
-            auto file = std::make_unique<pre_indexed_file>();
+            pre_indexed_file *file = new pre_indexed_file;
 
             file->tree = idx_tree;
-            file->repopath = repopath;
+            file->repopath = "abcd";
             file->path = path;
             file->score = score_file(full_path);
             file->repo = curr_repo;
             file->oid = (git_oid *)malloc(sizeof(git_oid));
             git_oid_cpy(file->oid, git_blob_id(obj));
 
-            results.push_back(std::move(file));
+            /* results.push_back(std::move(file)); */
+            /* fprintf(stderr, "about to push to global fq_\n"); */
+            fq_.push(file);
         } else if (git_tree_entry_type(*it) == GIT_OBJ_COMMIT) {
             // Submodule
             if (!walk_submodules) {
@@ -301,7 +480,7 @@ void git_indexer::walk_tree(const string& pfx,
                 print_last_git_err_and_exit(err);
             }
 
-            walk(sub_repo, string(revstr), sub_repopath, string(sub_name), meta, walk_submodules, new_submodule_prefix, results);
+            walk(sub_repo, string(revstr), sub_repopath, string(sub_name), meta, walk_submodules, new_submodule_prefix);
 
             // TODO: See if this is efficient enough. We're depending on
             // libgi2's shutdown to close these submodule repos, while we

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -83,7 +83,7 @@ void git_indexer::index_files() {
         const char *repopath = file->repopath.c_str();
         
         if (strcmp(prev_repopath, repopath) != 0) {
-            git_repository_free(curr_repo);
+            git_repository_free(curr_repo); // Will do nothing if curr_repo == NULL
             int err = git_repository_open(&curr_repo, repopath);
             if (err < 0) {
                 print_last_git_err_and_exit(err);
@@ -98,11 +98,7 @@ void git_indexer::index_files() {
         }
 
         const git_oid blob_id_static = static_cast<git_oid>(blob_id);
-
-
-        // now that the repo is open
         git_blob *blob;
-
         err = git_blob_lookup(&blob, curr_repo, &blob_id_static);
 
         if (err < 0) {
@@ -110,10 +106,9 @@ void git_indexer::index_files() {
         }
 
         const char *data = static_cast<const char*>(git_blob_rawcontent(blob));
-
         cs_->index_file(file->tree, file->path, StringPiece(data, git_blob_rawsize(blob)));
 
-        // why does this work?
+        git_blob_free(blob);
         prev_repopath = repopath;
     }
 

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -225,14 +225,7 @@ void git_indexer::walk_tree(const string& pfx,
             walk_tree(path + "/", "", repopath, walk_submodules, submodule_prefix, idx_tree, (git_tree*)obj, curr_repo);
         } else if (git_tree_entry_type(*it) == GIT_OBJ_BLOB) {
             const string full_path = submodule_prefix + path;
-            pre_indexed_file file;
-
-            file.tree = idx_tree;
-            file.repopath = repopath;
-            file.path =  full_path;
-            file.score = score_file(full_path);
-            file.repo = curr_repo;
-            file.obj = obj;
+            const pre_indexed_file file{idx_tree, repopath, path, score_file(full_path), curr_repo, obj};
 
             /* fprintf(stderr, "indexing %s/%s\n", repopath.c_str(), file.path.c_str()); */
             if (!files_to_index_local.get()) {

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -20,7 +20,7 @@ DEFINE_bool(revparse, false, "Display parsed revisions, rather than as-provided"
 
 git_indexer::git_indexer(code_searcher *cs,
                          const google::protobuf::RepeatedPtrField<RepoSpec>& repositories)
-    : cs_(cs), repositories_to_index_(repositories) {
+    : cs_(cs), repositories_to_index_(repositories), repositories_to_index_length_(repositories.size()) {
     int err;
     if ((err = git_libgit2_init()) < 0)
         die("git_libgit2_init: %s", giterr_last()->message);
@@ -39,13 +39,12 @@ git_indexer::~git_indexer() {
 }
 
 
-std::atomic<int> next_idx(0);
 // Used to get the next index of a repo a thread should focus on
 int git_indexer::get_next_repo_idx() {
-    if (next_idx == repositories_to_index_.size()) {
+    if (next_repo_to_process_idx_ == repositories_to_index_length_) {
         return -1;
     }
-    return next_idx++;
+    return next_repo_to_process_idx_++;
 }
 
 void git_indexer::print_last_git_err_and_exit(int err) {

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -49,7 +49,7 @@ void git_indexer::print_last_git_err_and_exit(int err) {
     exit(1);
 }
 
-void git_indexer::process_trees(int thread_id) {
+void git_indexer::process_trees() {
     tree_to_walk *d;
 
     while (trees_to_walk_.pop(&d)) {
@@ -112,7 +112,7 @@ void git_indexer::begin_indexing() {
     open_git_repos_.reserve(repositories_to_index_length_);
     threads_.reserve(num_threads);
     for (long i = 0; i < num_threads; ++i) {
-        threads_.emplace_back(&git_indexer::process_trees, this, i);
+        threads_.emplace_back(&git_indexer::process_trees, this);
     }
 
     // in both single and multi thread modes, try to bump the number of file

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -103,7 +103,7 @@ void git_indexer::index_repos() {
     // in both single and multi thread modes, try to bump the number of file
     // descriptors to the max allowed by the OS. We don't do any fancy attempts
     // at keeping the number of files <= max, we mostly just hope it will be
-    // enough. We can definetely keep track of that if it becomes necessary.
+    // enough. We can definitely keep track of that if it becomes necessary.
     if (FLAGS_increase_fds) {
         increaseOpenFileLimitToMax();
     }
@@ -144,7 +144,6 @@ void git_indexer::index_repos() {
     fprintf(stderr, "\nwalking repo trees...\n");
     for(;;)
     {
-        // We get the current size of the thing 
         int curr = trees_to_walk_.size();
         if (curr == 0) break;
         fprintf(stderr, "    %d remaining\n", curr);
@@ -264,7 +263,7 @@ void git_indexer::walk_tree(std::string pfx,
         it != ordered.end(); ++it) {
         
         // We use a plain git_object here rather than a smart object, since
-        // attatching a smart_object to tree_to_walk causes a segfault once we
+        // attaching a smart_object to tree_to_walk causes a segfault once we
         // try to access it, I'm assuming because the smart_object has been
         // released already. Not sure if I can avoid this somehow...
         // For now, use a plain git_object. If the object is a blob, we free it
@@ -311,7 +310,7 @@ void git_indexer::walk_tree(std::string pfx,
 
             git_object_free(obj); // free the blob
 
-            // This is as fast or faster, belive it or not, than using a queue
+            // This is as fast or faster, believe it or not, than using a queue
             // per thread, then pushing the results onto the global list after
             // each thread is done.
             std::lock_guard<std::mutex> guard(files_mutex_);

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -31,8 +31,8 @@ git_indexer::git_indexer(code_searcher *cs,
 git_indexer::~git_indexer() {
     git_libgit2_shutdown();
 
-    for (auto it = threads_.begin(); it != threads_.end(); ++it)
-        it->join();
+    /* for (auto it = threads_.begin(); it != threads_.end(); ++it) */
+    /*     it->join(); */
 }
 
 void git_indexer::print_last_git_err_and_exit(int err) {
@@ -188,7 +188,7 @@ void git_indexer::index_files() {
         prev_repopath = repopath;
     }
 
-    fprintf(stderr, "done\n");
+    fprintf(stderr, "finished with index_files\n");
 }
 
 void git_indexer::walk(git_repository *curr_repo,

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -39,13 +39,6 @@ git_indexer::~git_indexer() {
 }
 
 
-// Used to get the next index of a repo a thread should focus on
-int git_indexer::get_next_repo_idx() {
-    if (next_repo_to_process_idx_.load() == repositories_to_index_length_) {
-        return -1;
-    }
-    return next_repo_to_process_idx_.fetch_add(1, std::memory_order_relaxed);
-}
 
 void git_indexer::print_last_git_err_and_exit(int err) {
     const git_error *e = giterr_last();
@@ -53,94 +46,14 @@ void git_indexer::print_last_git_err_and_exit(int err) {
     exit(1);
 }
 
-/* void git_indexer::process_repos(int estimatedReposToProcess, threadsafe_progress_indicator *tpi) { */
-/*     int idx_to_process = get_next_repo_idx(); */
-/*     std::vector<git_repository *> open_git_repos_local; */
-/*     std::vector<std::unique_ptr<pre_indexed_file>> files_to_index_local; */
-
-/*     open_git_repos_local.reserve(estimatedReposToProcess); */
-/*     files_to_index_local.reserve(estimatedReposToProcess * 100); */
-
-/*     while (idx_to_process >= 0) { */
-/*         /1* fprintf(stderr, "going to process: %d\n", idx_to_process); *1/ */
-/*         /1* auto start = high_resolution_clock::now(); *1/ */
-/*         const auto &repo = repositories_to_index_[idx_to_process]; */
-/*         const char *repopath = repo.path().c_str(); */
-
-/*         /1* fprintf(stderr, "walking repo: %s\n", repopath); *1/ */
-/*         git_repository *curr_repo = NULL; */
-
-/*         // Is it safe to assume these are bare repos (or the mirror clones) */
-/*         // that we create?. If so, we can use git_repository_open_bare */
-/*         int err = git_repository_open_bare(&curr_repo, repopath); */
-/*         if (err < 0) { */
-/*             print_last_git_err_and_exit(err); */
-/*         } */
-
-/*         open_git_repos_local.push_back(curr_repo); */
-
-/*         /1* for (auto &rev : repo.revisions()) { *1/ */
-/*             /1* fprintf(stderr, "walking %s at %s \n", repopath, rev.c_str()); *1/ */
-/*             /1* walk(curr_repo, rev, repo.path(), repo.name(), repo.metadata(), repo.walk_submodules(), "", files_to_index_local); *1/ */
-/*             /1* fprintf(stderr, "done walking %s at %s\n", repopath, rev.c_str()); *1/ */
-/*             /1* tpi->tick(); *1/ */
-/*         /1* } *1/ */
-/*         /1* auto stop = high_resolution_clock::now(); *1/ */
-/*         /1* auto duration = duration_cast<seconds>(stop - start); *1/ */
-/*         /1* cout << "took: " << duration.count() << " seconds to process_repos" << endl; *1/ */
-
-/*         idx_to_process = get_next_repo_idx(); */
-/*     } */
-
-/*     std::lock_guard<std::mutex> guard(files_mutex_); */
-/*     files_to_index_.insert(files_to_index_.end(), std::make_move_iterator(files_to_index_local.begin()), std::make_move_iterator(files_to_index_local.end())); */
-/*     open_git_repos_.insert(open_git_repos_.end(), open_git_repos_local.begin(), open_git_repos_local.end()); */
-/* } */
 void git_indexer::process_trees(int thread_id) {
-    fprintf(stderr, "thread %d listening\n", thread_id);
     tree_to_walk *d;
 
     while (trees_to_walk_.pop(&d)) {
-        // got a t with
-        /* fprintf(stderr, "thread[%d] popped an elem off the stack\n", thread_id); */
-        /* std::cout << t; */
-
-        /* std::cout << "Name: " << d->name << " repopath: " << d->repopath << std::endl; */
-
-        /* std::cout << "repopath: " << d->repopath << std::endl; */
-        /* fprintf(stderr, "thread[%d]: %s/%s\n", thread_id, d->repopath.c_str(), d->prefix.c_str()); */
-
-        /* std::cout << "Id addr: " << tree << std::endl; */
-              /* << "walk_submodules: " << tree->walk_submodules << std::endl */
-              /* << "submodule_prefix: " << tree->submodule_prefix << std::endl */
-              /* << "idx_tree.name " << tree->idx_tree->name << std::endl; */
-        /* fprintf(stderr, "[%d]: walk_tree('%s','%s','%s')\n", thread_id, tree->prefix.c_str(), tree->order.c_str(), tree->repopath.c_str()); */
         walk_tree(d->prefix, d->order, d->repopath, d->walk_submodules, 
                 d->submodule_prefix, d->idx_tree, d->tree, d->repo, 1);
     }
 }
-
-/* void git_indexer::process_trees(int thread_id) { */
-/*     fprintf(stderr, "thread %d listening\n", thread_id); */
-/*     tree_to_walk *tree; */
-
-/*     while (trees_to_walk_.pop(&tree)) { */
-/*         // got a t with */
-/*         fprintf(stderr, "thread[%d] popped an elem off the stack\n", thread_id); */
-/*         /1* std::cout << t; *1/ */
-/*         std::cout << "Id: " << tree->id << std::endl */ 
-/*               << "Prefix: " << tree->prefix << std::endl */
-/*               << "Order: " << tree->order << std::endl */
-/*               << "repopath: " << tree->repopath << std::endl;; */
-/*         fprintf(stderr, "\n"); */
-/*               /1* << "walk_submodules: " << tree->walk_submodules << std::endl *1/ */
-/*               /1* << "submodule_prefix: " << tree->submodule_prefix << std::endl *1/ */
-/*               /1* << "idx_tree.name " << tree->idx_tree->name << std::endl; *1/ */
-/*         /1* fprintf(stderr, "[%d]: walk_tree('%s','%s','%s')\n", thread_id, tree->prefix.c_str(), tree->order.c_str(), tree->repopath.c_str()); *1/ */
-/*         walk_tree(tree->prefix, tree->order, tree->repopath, tree->walk_submodules, */ 
-/*                 tree->submodule_prefix, tree->idx_tree, tree->tree, tree->repo, 1); */
-/*     } */
-/* } */
 
 void git_indexer::begin_indexing() {
 
@@ -192,56 +105,12 @@ void git_indexer::begin_indexing() {
         open_git_repos_.push_back(curr_repo);
 
         for (auto &rev : repo.revisions()) {
-            /* fprintf(stderr, "walking %s at %s \n", repopath, rev.c_str()); */
             walk(curr_repo, rev, repo.path(), repo.name(), repo.metadata(), repo.walk_submodules(), "");
-            /* tree_to_walk t{ */
-            /*     std::rand(), */
-            /*     "/", */
-            /*     "", */
-            /*     repo.path(), */
-            /*     false, */
-            /*     "", */
-            /* }; */
-            /* tree_to_walk t{}; */
-            /* t.repopath = repopath; */
-            /* t.prefix = path + "/"; */
-            
-        /* fprintf(stderr, "t is initially ----\n"); */
-        /* fprintf(stderr, "repopath.size(): %lu\n", repopath.size()); */
-        /* std::cout << "Prefix: " << t.prefix << std::endl */
-        /*       << "Order: " << t.order << std::endl */
-        /*       << "repopath: " << t.repopath << std::endl */
-        /*       << "walk_submodules: " << t.walk_submodules << std::endl */
-        /*       << "submodule_prefix: " << t.submodule_prefix << std::endl */
-        /*       << "idx_tree.name " << t.idx_tree->name << std::endl; */
-            /* fprintf(stderr, "about to push to trees_to_walk_ id: %d\n", t.id); */
-            /* trees_to_walk_.push(&t); */
-            /* fprintf(stderr, "done walking %s at %s\n", repopath, rev.c_str()); */
         }
-        /* tpi.tick(); */
+        tpi.tick();
      }
 
-     // ahhh, this may have to be rethought. When we're done walking repos
-     // it doesn't mean that all of the subdirectories have been traversed
-     // So if we close this, we may run into problems.
-
-
-
-    /* if (length < 2 * min_per_thread) { */
-    /*     fprintf(stderr, "Not going to create any new threads.\n"); */
-    /*     process_repos(length, &tpi); */
-    /*     index_files(); */
-    /*     return; */
-    /* } */
-
-    /* int estimatedReposPerThread = length / num_threads; */
-    /* threads_.reserve(num_threads - 1); */
-    /* auto start = high_resolution_clock::now(); */
-    /* for (long i = 0; i < num_threads; ++i) { */
-    /*     threads_.emplace_back(&git_indexer::process_repos, this, estimatedReposPerThread, &tpi); */
-    /* } */
-
-    fprintf(stderr, "waiting for threads\n");
+    fprintf(stderr, "walking inner trees trees...\n");
 
     // we can close the trees, since we only add to trees_to_walk_ at the
     // root/unordered level
@@ -249,6 +118,7 @@ void git_indexer::begin_indexing() {
     for (long i = 0; i < num_threads; ++i) {
         threads_[i].join();
     }
+    fprintf(stderr, "    done.\n");
 
     // but we can't close the fq_ until all trees have been processed
     fq_.close();
@@ -256,11 +126,10 @@ void git_indexer::begin_indexing() {
     auto duration = duration_cast<milliseconds>(stop - start);
     cout << "took: " << duration.count() << " milliseconds to process_repos" << endl;
     /* exit(0); */
+
     pre_indexed_file *p;
 
-
     while (fq_.pop(&p)) {
-        /* fprintf(stderr, "pushing back some stuff\n"); */
         files_to_index_.push_back(p);
     }
     fprintf(stderr, "done waiting\n");
@@ -270,11 +139,11 @@ void git_indexer::begin_indexing() {
     index_files();
 }
 
-bool compareFilesByScore(const std::unique_ptr<pre_indexed_file>& a, const std::unique_ptr<pre_indexed_file>& b) {
+bool compareFilesByScore(pre_indexed_file *a, pre_indexed_file *b) {
     return a->score > b->score;
 }
 
-bool compareFilesByTree(const std::unique_ptr<pre_indexed_file>& a, const std::unique_ptr<pre_indexed_file>& b) {
+bool compareFilesByTree(pre_indexed_file *a, pre_indexed_file *b) {
     return a->tree->name < b->tree->name;
 }
 
@@ -288,13 +157,18 @@ bool compareFilesByTree(const std::unique_ptr<pre_indexed_file>& a, const std::u
 // walks `files_to_index_`, looks up the repo & blob combination for each file
 // and then calls `cs->index_file` to actually index the file.
 void git_indexer::index_files() {
-    /* fprintf(stderr, "sorting files_to_index_ by tree... [%lu]\n", files_to_index_.size()); */
-    /* std::stable_sort(files_to_index_.begin(), files_to_index_.end(), compareFilesByTree); */
-    /* fprintf(stderr, "  done\n"); */
+    auto start = high_resolution_clock::now();
+    fprintf(stderr, "sorting files_to_index_ by tree... [%lu]\n", files_to_index_.size());
+    std::stable_sort(files_to_index_.begin(), files_to_index_.end(), compareFilesByTree);
+    fprintf(stderr, "  done\n");
 
-    /* fprintf(stderr, "sorting files_to_index_ by score... [%lu]\n", files_to_index_.size()); */
-    /* std::stable_sort(files_to_index_.begin(), files_to_index_.end(), compareFilesByScore); */
-    /* fprintf(stderr, "  done\n"); */
+    fprintf(stderr, "sorting files_to_index_ by score... [%lu]\n", files_to_index_.size());
+    std::stable_sort(files_to_index_.begin(), files_to_index_.end(), compareFilesByScore);
+    fprintf(stderr, "  done\n");
+    auto stop = high_resolution_clock::now();
+    auto duration = duration_cast<milliseconds>(stop - start);
+    cout << "took: " << duration.count() << " milliseconds to sort repos twice" << endl;
+
 
     /* fprintf(stderr, "walking files_to_index_ ...\n"); */
     threadsafe_progress_indicator tpi(files_to_index_.size(), "Indexing files_to_index_...", "Done");
@@ -353,20 +227,9 @@ void git_indexer::walk_tree(std::string pfx,
                             git_repository *curr_repo,
                             int depth) {
     /* fprintf(stderr, "[%d] preparing to walk_tree for %s with prefix: %s \n", depth, repopath.c_str(), pfx.c_str()); */
-    /* if (depth == 1) { */
-    /*     return; */
-    /* } */
     map<string, const git_tree_entry *> root;
     int entries = git_tree_entrycount(tree);
 
-    /* fprintf(stderr, "repo: %s has %d entries\n", repopath.c_str(), entries); */
-    /* fprintf(stderr, "%s/%s filled git_tree_entry map ok\n", repopath.c_str(), pfx.c_str()); */
-
-    /* for (map<string, const git_tree_entry *>::iterator it = root.begin(); */
-    /*      it != root.end(); ++it) */
-    /*     ordered.push_back(it->second); */
-
-    /* for (vector<const git_tree_entry *>::iterator it = ordered.begin(); it != ordered.end(); ++it) { */
     for (int i = 0; i < entries; ++i) {
         const git_tree_entry *ent = git_tree_entry_byindex(tree, i);
         
@@ -377,14 +240,8 @@ void git_indexer::walk_tree(std::string pfx,
         /* fprintf(stderr, "walking obj with path: %s/%s\n", repopath.c_str(), path.c_str()); */
 
         if (git_tree_entry_type(ent) == GIT_OBJ_TREE) {
-            /* fprintf(stderr, "entry is git_tree\n"); */
-            // But more likely, when depth == 1, we could add these to a thread
-            // pool. In that way, a repo could "potentially" be walked by 10
-            // threads at a time
-            /* fprintf(stderr, "going to add repopath with %s\n", repopath.c_str()); */
             if (depth == 1) { // don't add to the thread workload
                 walk_tree(path + "/", "", repopath, walk_submodules, submodule_prefix, idx_tree, obj, curr_repo, 1);
-                /* return; */
             } else {
                 tree_to_walk *t = new tree_to_walk;
                 t->prefix = path + "/";
@@ -399,48 +256,9 @@ void git_indexer::walk_tree(std::string pfx,
                 t->tree = (git_tree *)(obj1);
                 t->repo = curr_repo;
 
-
                 trees_to_walk_.push(t);
-
             }
-
-
-            /* auto tree = std::make_unique<tree_to_walk>(); */
-            /* tree_to_walk t{ */
-            /*     std::rand(), */
-            /*     path + "/", */
-            /*     "", */
-            /*     repopath + "/", */
-            /*     walk_submodules, */
-            /*     submodule_prefix, */
-            /*     idx_tree, */
-            /*     obj, */
-            /*     curr_repo, */
-            /* }; */
-            /* tree_to_walk t{}; */
-            /* t.repopath = repopath; */
-            /* t.prefix = path + "/"; */
-            
-        /* fprintf(stderr, "t is initially ----\n"); */
-        /* fprintf(stderr, "repopath.size(): %lu\n", repopath.size()); */
-        /* std::cout << "Prefix: " << t.prefix << std::endl */
-        /*       << "Order: " << t.order << std::endl */
-        /*       << "repopath: " << t.repopath << std::endl */
-        /*       << "walk_submodules: " << t.walk_submodules << std::endl */
-        /*       << "submodule_prefix: " << t.submodule_prefix << std::endl */
-        /*       << "idx_tree.name " << t.idx_tree->name << std::endl; */
-            /* fprintf(stderr, "about to push to trees_to_walk_ id: %d\n", t.id); */
-            /* trees_to_walk_.push(&t); */
-
-            /* dummy *d = new dummy; */
-            /* d->name = "hello = " + repopath; */
-            /* d->repopath = repopath; */
-            /* trees_to_walk_.push(d); */
-
-            /* walk_tree(path + "/", "", repopath, walk_submodules, submodule_prefix, idx_tree, obj, curr_repo, results); */
         } else if (git_tree_entry_type(ent) == GIT_OBJ_BLOB) {
-            /* fprintf(stderr, "entry is blob\n"); */
-
             const string full_path = submodule_prefix + path;
 
             pre_indexed_file *file = new pre_indexed_file;
@@ -453,8 +271,6 @@ void git_indexer::walk_tree(std::string pfx,
             file->oid = (git_oid *)malloc(sizeof(git_oid));
             git_oid_cpy(file->oid, git_blob_id(obj));
 
-            /* results.push_back(std::move(file)); */
-            /* fprintf(stderr, "about to push to global fq_\n"); */
             fq_.push(file);
         } else if (git_tree_entry_type(ent) == GIT_OBJ_COMMIT) {
             // Submodule

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -18,66 +18,44 @@ DEFINE_bool(revparse, false, "Display parsed revisions, rather than as-provided"
 
 git_indexer::git_indexer(code_searcher *cs,
                          const google::protobuf::RepeatedPtrField<RepoSpec>& repositories)
-    : cs_(cs), repo_(0), repositories_to_index_(repositories) {
+    : cs_(cs), repositories_to_index_(repositories) {
     int err;
     if ((err = git_libgit2_init()) < 0)
         die("git_libgit2_init: %s", giterr_last()->message);
 
-    /* git_repository_open(&repo_, repopath.c_str()); */
-    /* if (repo_ == NULL) { */
-    /*     fprintf(stderr, "Unable to open repo: %s\n", repopath.c_str()); */
-    /*     exit(1); */
-    /* } */
     git_libgit2_opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, GIT_OBJ_BLOB, 10*1024);
     git_libgit2_opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, GIT_OBJ_OFS_DELTA, 10*1024);
     git_libgit2_opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, GIT_OBJ_REF_DELTA, 10*1024);
 }
 
+// Do nothing on close.
 git_indexer::~git_indexer() {
-    // This should do nothing if repo_ is null
-    git_repository_free(repo_);
 }
 
 void git_indexer::begin_indexing() {
-    // first, go through all repos and sort all the files possible
-    // then, go through and actually call cs.index_file on all of them
 
     // The below will populate files_to_index_
     for (auto &repo : repositories_to_index_) {
-        repopath_ = repo.path();
-        const char *repopath = repopath_.c_str();
+        /* repopath_ = repo.path(); */
+        const char *repopath = repo.path().c_str();
 
         fprintf(stderr, "indexing repo: %s\n", repopath);
         // if repo has already been set AND it's not the same as this one
-        if (repo_ != NULL && strcmp(git_repository_path(repo_), repopath) != 0 ) {
-            // Free the old repository
-            git_repository_free(repo_);
+        git_repository *curr_repo;
 
-            // open the new repository
-            int err = git_repository_open(&repo_, repopath);
-            if (err < 0) {
-                fprintf(stderr, "Unable to open repo: %s\n", repopath);
-                exit(1);
-            }
-        } else { // if we haven't opened a repo yet
-            int err = git_repository_open(&repo_, repopath);
-            if (err < 0) {
-                fprintf(stderr, "Unable to open repo: %s\n", repopath);
-                exit(1);
-            }
+        int err = git_repository_open(&curr_repo, repopath);
+        if (err < 0) {
+            fprintf(stderr, "Unable to open repo: %s\n", repopath);
+            exit(1);
         }
-
-        name_ = repo.name();
-        metadata_ = repo.metadata();
-        walk_submodules_ = repo.walk_submodules();
 
         for (auto &rev : repo.revisions()) {
-            walk(rev);
+            walk(curr_repo, rev, repo.path(), repo.name(), repo.metadata(), repo.walk_submodules(), "");
         }
+
+        git_repository_free(curr_repo);
     }
 
-    // close the most recent repo opened
-    git_repository_free(repo_);
     index_files();
 }
 
@@ -95,10 +73,12 @@ void git_indexer::index_files() {
 
     std::stable_sort(files_to_index_.begin(), files_to_index_.end());
 
+    git_repository *curr_repo;
     for (auto it = files_to_index_.begin(); it != files_to_index_.end(); ++it) {
         auto file = it->get();
 
         const char *repopath = file->repopath.c_str();
+        git_repository_open(&curr_repo, repopath);
         fprintf(stderr, "%s/%s. id: %s \n", repopath, file->path.c_str(), file->id.c_str()); 
 
         git_oid blob_id;
@@ -112,38 +92,20 @@ void git_indexer::index_files() {
 
         const git_oid blob_id_static = static_cast<git_oid>(blob_id);
 
-        /* git_repository_open(&repo_, repopath); */
 
-        fprintf(stderr, "open at: %s\n", git_repository_path(repo_));
+        fprintf(stderr, "open at: %s\n", git_repository_path(curr_repo));
+        fprintf(stderr, "repopath: %s\n", repopath);
+        /* string repo_path = string(git_repository_path(repo_)); */
+        /* fprintf(stderr, "equal: %d\n", strcmp(repo_path + strlen(repo_path) - (strlen(file->repopath) + 1), file->repopath + "/") == 0); */
 
         
-        if (git_repository_path(repo_) != NULL && strcmp(git_repository_path(repo_), repopath) != 0 ) {
-            fprintf(stderr, "freeing the old repo...\n");
-            // Free the old repository
-            git_repository_free(repo_);
 
-            // open the new repository
-            git_repository_open(&repo_, repopath);
-            if (repo_ == NULL) {
-                fprintf(stderr, "Unable to open repo: %s\n", repopath);
-                exit(1);
-            }
-        } else if (git_repository_path(repo_) == NULL) { // if we haven't opened a repo yet
-            fprintf(stderr, "repo_ is null, trying to open..\n");
-            git_repository_open(&repo_, repopath);
-            if (repo_ == NULL) {
-                fprintf(stderr, "Unable to open repo: %s\n", repopath);
-                exit(1);
-            }
-        }
-
-        fprintf(stderr, "_repo opened at path: %s\n", git_repository_path(repo_));
+        fprintf(stderr, "_repo opened at path: %s\n", git_repository_path(curr_repo));
 
         // now that the repo is open
         git_blob *blob;
-        /* int err = git_blob_lookup(&blob, repo_, file->id); */
 
-        err = git_blob_lookup(&blob, repo_, &blob_id_static);
+        err = git_blob_lookup(&blob, curr_repo, &blob_id_static);
 
         if (err < 0) {
             const git_error *e = giterr_last();
@@ -159,15 +121,22 @@ void git_indexer::index_files() {
         fprintf(stderr, "data loaded (theoretically)\n");
         cs_->index_file(file->tree, file->path, StringPiece(data, git_blob_rawsize(blob)));
 
+        git_repository_free(curr_repo);
     }
 
     fprintf(stderr, "finished looping\n");
 }
 
-void git_indexer::walk(const string& ref) {
+void git_indexer::walk(git_repository *curr_repo,
+        const string& ref, 
+        const string repopath, 
+        const string& name,
+        Metadata metadata,
+        bool walk_submodules,
+        const string& submodule_prefix) {
     smart_object<git_commit> commit;
     smart_object<git_tree> tree;
-    if (0 != git_revparse_single(commit, repo_, (ref + "^0").c_str())) {
+    if (0 != git_revparse_single(commit, curr_repo, (ref + "^0").c_str())) {
         fprintf(stderr, "ref %s not found, skipping (empty repo?)\n", ref.c_str());
         return;
     }
@@ -177,14 +146,20 @@ void git_indexer::walk(const string& ref) {
     string version = FLAGS_revparse ?
         strdup(git_oid_tostr(oidstr, sizeof(oidstr), git_commit_id(commit))) : ref;
 
-    idx_tree_ = cs_->open_tree(name_, metadata_, version);
-    walk_tree("", FLAGS_order_root, tree);
+    const indexed_tree *idx_tree = cs_->open_tree(name, metadata, version);
+    walk_tree("", FLAGS_order_root, repopath, walk_submodules, submodule_prefix, idx_tree, tree, curr_repo);
 }
 
 
 void git_indexer::walk_tree(const string& pfx,
                             const string& order,
-                            git_tree *tree) {
+                            const string repopath,
+                            bool walk_submodules,
+                            const string& submodule_prefix,
+                            const indexed_tree *idx_tree,
+                            git_tree *tree,
+                            git_repository *curr_repo) {
+
     map<string, const git_tree_entry *> root;
     vector<const git_tree_entry *> ordered;
     int entries = git_tree_entrycount(tree);
@@ -208,20 +183,20 @@ void git_indexer::walk_tree(const string& pfx,
     for (vector<const git_tree_entry *>::iterator it = ordered.begin();
          it != ordered.end(); ++it) {
         smart_object<git_object> obj;
-        git_tree_entry_to_object(obj, repo_, *it);
+        git_tree_entry_to_object(obj, curr_repo, *it);
         string path = pfx + git_tree_entry_name(*it);
 
         if (git_tree_entry_type(*it) == GIT_OBJ_TREE) {
-            walk_tree(path + "/", "", obj);
+            walk_tree(path + "/", "", repopath, walk_submodules, submodule_prefix, idx_tree, obj, curr_repo);
         } else if (git_tree_entry_type(*it) == GIT_OBJ_BLOB) {
             const git_oid* blob_id = git_blob_id(obj);
             char blob_id_str[GIT_OID_HEXSZ + 1];
             git_oid_tostr(blob_id_str, GIT_OID_HEXSZ + 1, blob_id);
 
-            const string full_path = submodule_prefix_ + path;
+            const string full_path = submodule_prefix + path;
             auto file = std::make_unique<pre_indexed_file>();
-            file->tree = idx_tree_;
-            file->repopath = repopath_;
+            file->tree = idx_tree;
+            file->repopath = repopath;
             file->path =  full_path;
             file->score = score_file(full_path);
 
@@ -233,7 +208,7 @@ void git_indexer::walk_tree(const string& pfx,
             // I need to copy the oid back and forth, otherwise I run into that
             // indeterminate behavior thats described
             
-            fprintf(stderr, "%s/%s -> %s\n", repopath_.c_str(), full_path.c_str(), git_oid_tostr_s(blob_id));
+            fprintf(stderr, "%s/%s -> %s\n", repopath.c_str(), full_path.c_str(), git_oid_tostr_s(blob_id));
             fprintf(stderr, "id_test: %s\n", file->id.c_str());
             fprintf(stderr, "id_test2 raw 20 bytes: [%s]\n", file->id_test2);
 
@@ -244,26 +219,42 @@ void git_indexer::walk_tree(const string& pfx,
             /* cs_->index_file(idx_tree_, submodule_prefix_ + path, StringPiece(data, git_blob_rawsize(obj))); */
         } else if (git_tree_entry_type(*it) == GIT_OBJ_COMMIT) {
             // Submodule
-            if (!walk_submodules_) {
+            if (!walk_submodules) {
                 continue;
             }
             git_submodule* submod = nullptr;
-            if (0 != git_submodule_lookup(&submod, repo_, path.c_str())) {
+            if (0 != git_submodule_lookup(&submod, curr_repo, path.c_str())) {
                 fprintf(stderr, "Unable to get submodule entry for %s, skipping\n", path.c_str());
                 continue;
             }
+
             const char* sub_name = git_submodule_name(submod);
-            string sub_repopath = repopath_ + "/" + path;
+            string sub_repopath = repopath + "/" + path;
+            string new_submodule_prefix = submodule_prefix + path + "/";
             Metadata meta;
 
             /* git_indexer sub_indexer(cs_, sub_repopath, string(sub_name), meta, walk_submodules_); */
             /* sub_indexer.submodule_prefix_ = submodule_prefix_ + path + "/"; */
 
-            /* const git_oid* rev = git_tree_entry_id(*it); */
-            /* char revstr[GIT_OID_HEXSZ + 1]; */
-            /* git_oid_tostr(revstr, GIT_OID_HEXSZ + 1, rev); */
+            const git_oid* rev = git_tree_entry_id(*it);
+            char revstr[GIT_OID_HEXSZ + 1];
+            git_oid_tostr(revstr, GIT_OID_HEXSZ + 1, rev);
 
             /* sub_indexer.walk(string(revstr)); */
+
+            // Open the submodule repo
+            git_repository *sub_repo;
+
+            int err = git_repository_open(&sub_repo, sub_repopath.c_str());
+
+            if (err < 0) {
+                fprintf(stderr, "Unable to open subrepo: %s\n", sub_repopath.c_str());
+                exit(1);
+            }
+
+            walk(sub_repo, string(revstr), sub_repopath, string(sub_name), meta, walk_submodules, new_submodule_prefix);
+
+            git_repository_free(sub_repo);
         }
     }
 }

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -79,9 +79,6 @@ void git_indexer::walk_repositories_subset(int start, int end) {
 
 void git_indexer::begin_indexing() {
 
-    for (auto &repo : repositories_to_index_) {
-        fprintf(stderr, "going to index: %s\n", repo.path().c_str());
-    }
     // min_per_thread will require tweaking. For example, even with only
     // 2 repos, would it not be worth it to spin up two threads (if available)?
     // Or would the overhead of the thread creation far outweigh the single-core

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -248,6 +248,10 @@ void git_indexer::walk_tree(const string& pfx,
 
             const string full_path = submodule_prefix + path;
             auto file = std::make_unique<pre_indexed_file>();
+            // There's probably a better way than this, but for some reason
+            // storing the oid as either a git_oid or it's raw representation 
+            // (unisgned char* [20]) ends up with the stored oid becoming
+            // mutated. For now simply copying it to a string works.
             file->id = string(blob_id_str);
             file->tree = idx_tree;
             file->repopath = repopath;

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -170,7 +170,8 @@ bool compareFilesByTree(pre_indexed_file *a, pre_indexed_file *b) {
 // get indexed last, and so show up in sorts results last. We use a stable sort
 // so that most of a repos files are indexed together
 void git_indexer::index_files() {
-    // in multi-threaded mode, we sort by tree since a tree/repos files could
+
+    // in multi-threaded mode, we also sort by tree since a tree/repos files could
     // have ended up at any index. If FLAGS_order_root is set, then
     // multi-threading is disabled, so we don't have to re-check
     if (!is_singlethreaded_) {

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -28,8 +28,8 @@ git_indexer::git_indexer(code_searcher *cs,
     git_libgit2_opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, GIT_OBJ_REF_DELTA, 10*1024);
 }
 
-// Do nothing on close.
 git_indexer::~git_indexer() {
+    git_libgit2_shutdown();
 }
 
 void git_indexer::begin_indexing() {

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -167,11 +167,6 @@ void git_indexer::index_files() {
         auto file = it->get();
 
         git_blob *blob;
-        // TODO: Test and ensure that duplicate files across repos have unique
-        // oid's. I believe the odds of duplicate id's, even across multiple
-        // files is extremely low
-        // However, since we have "all" repos open at the same time, what
-        // happens to git_blob_lookup if there are duplicated oid's present?
         int err = git_blob_lookup(&blob, file->repo, file->oid);
 
         if (err < 0) {

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -39,7 +39,7 @@ void git_indexer::begin_indexing() {
         /* repopath_ = repo.path(); */
         const char *repopath = repo.path().c_str();
 
-        fprintf(stderr, "indexing repo: %s\n", repopath);
+        fprintf(stderr, "walking repo: %s\n", repopath);
         // if repo has already been set AND it's not the same as this one
         git_repository *curr_repo = NULL;
 
@@ -50,7 +50,9 @@ void git_indexer::begin_indexing() {
         }
 
         for (auto &rev : repo.revisions()) {
+            fprintf(stderr, " walking %s... ", rev.c_str());
             walk(curr_repo, rev, repo.path(), repo.name(), repo.metadata(), repo.walk_submodules(), "");
+            fprintf(stderr, "done\n");
         }
 
         git_repository_free(curr_repo);
@@ -64,26 +66,20 @@ bool operator<(std::unique_ptr<pre_indexed_file>& a, std::unique_ptr<pre_indexed
 }
 
 void git_indexer::index_files() {
-    // the idea here would be to get all the files from all repos.
-    // Then sort them
-    // How would we go back to every file?
-    fprintf(stderr, "have %ld files\n", files_to_index_.size());
-    // we seem to have an extra file?
-    // pre-sort
-
+    fprintf(stderr, "sorting files_to_index_... ");
     std::stable_sort(files_to_index_.begin(), files_to_index_.end());
+    fprintf(stderr, "done\n");
 
     git_repository *curr_repo = NULL;
     const char *prev_repopath = "";
 
-    fprintf(stderr, "we here\n");
+    fprintf(stderr, "walking files_to_index_ ...\n");
     for (auto it = files_to_index_.begin(); it != files_to_index_.end(); ++it) {
         auto file = it->get();
 
         const char *repopath = file->repopath.c_str();
         
         if (strcmp(prev_repopath, repopath) != 0) {
-            fprintf(stderr, "changing repos\n");
             git_repository_free(curr_repo);
             git_repository_open(&curr_repo, repopath);
         }
@@ -133,7 +129,7 @@ void git_indexer::index_files() {
         prev_repopath = repopath;
     }
 
-    /* fprintf(stderr, "finished looping\n"); */
+    fprintf(stderr, "done\n");
 }
 
 void git_indexer::walk(git_repository *curr_repo,

--- a/src/git_indexer.cc
+++ b/src/git_indexer.cc
@@ -56,6 +56,7 @@ void git_indexer::process_trees() {
         walk_tree(d->prefix, "", d->repopath, d->walk_submodules, 
                 d->submodule_prefix, d->idx_tree, d->tree, d->repo, 1);
         git_tree_free(d->tree);
+        delete(d);
     }
 }
 
@@ -183,6 +184,7 @@ void git_indexer::index_files() {
 
         git_blob *blob;
         int err = git_blob_lookup(&blob, file->repo, file->oid);
+        free(file->oid);
 
         if (err < 0) {
             print_last_git_err_and_exit(err);
@@ -192,6 +194,7 @@ void git_indexer::index_files() {
         cs_->index_file(file->tree, file->path, StringPiece(data, git_blob_rawsize(blob)));
 
         git_blob_free(blob);
+        delete(file);
         tpi.tick();
     }
 }

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -37,7 +37,7 @@ public:
     void begin_indexing();
 protected:
     int get_next_repo_idx();
-    void process_repos(threadsafe_progress_indicator *tpi);
+    void process_repos(int estimatedReposToProcess, threadsafe_progress_indicator *tpi);
     void walk(git_repository *curr_repo,
             const std::string& ref,
             const std::string& repopath,
@@ -57,7 +57,6 @@ protected:
                    std::vector<std::unique_ptr<pre_indexed_file>>& results);
     void index_files();
     void print_last_git_err_and_exit(int err);
-    void walk_repositories_subset(int start, int end, threadsafe_progress_indicator *tpi);
 
     code_searcher *cs_;
     std::string submodule_prefix_;

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -31,6 +31,8 @@ public:
     git_indexer(code_searcher *cs,
                 const google::protobuf::RepeatedPtrField<RepoSpec>& repositories);
     ~git_indexer();
+    void begin_indexing();
+protected:
     void walk(git_repository *curr_repo,
             const std::string& ref,
             const std::string repopath,
@@ -38,8 +40,6 @@ public:
             Metadata metadata,
             bool walk_submodules,
             const std::string& submodule_prefix);
-    void begin_indexing();
-protected:
     void walk_tree(const std::string& pfx,
                    const std::string& order,
                    const std::string repopath,
@@ -49,6 +49,7 @@ protected:
                    git_tree *tree,
                    git_repository *curr_repo);
     void index_files();
+    void print_last_git_err_and_exit(int err);
 
     code_searcher *cs_;
     std::string submodule_prefix_;

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -25,6 +25,7 @@ struct pre_indexed_file {
     std::string  repopath;
     std::string  path;
     std::string id; // git oid
+    std::unique_ptr<git_oid> oid;
     int score;
     git_repository *repo;
 };

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -23,7 +23,6 @@ struct pre_indexed_file {
      std::string  repopath;
      std::string  path;
      std::string id; // string version of oid
-     const unsigned char * id_test2;
      int score;
 };
 

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -24,6 +24,7 @@ struct pre_indexed_file {
      std::string  path;
      std::string id; // string version of oid
      const unsigned char * id_test2;
+     int score;
 };
 
 class git_indexer {

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -24,9 +24,9 @@ struct pre_indexed_file {
     const indexed_tree *tree;
     std::string  repopath;
     std::string  path;
+    std::string id; // git oid
     int score;
     git_repository *repo;
-    git_blob *blob;
 };
 
 class git_indexer {
@@ -61,6 +61,7 @@ protected:
     std::string submodule_prefix_;
     const google::protobuf::RepeatedPtrField<RepoSpec>& repositories_to_index_;
     std::vector<std::unique_ptr<pre_indexed_file>> files_to_index_;
+    std::vector<git_repository *> open_git_repos_;
     std::mutex files_mutex_;
     std::vector<std::thread> threads_;
 };

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -11,7 +11,6 @@
 #include <string>
 #include "src/proto/config.pb.h"
 #include "src/smart_git.h"
-/* #include "src/lib/per_thread.h" */
 #include "src/lib/threadsafe_progress_indicator.h"
 #include "src/lib/thread_queue.h"
 
@@ -53,8 +52,7 @@ public:
     ~git_indexer();
     void begin_indexing();
 protected:
-    int get_next_repo_idx();
-    void process_repos(int estimatedReposToProcess, threadsafe_progress_indicator *tpi);
+    void process_trees();
     void walk(git_repository *curr_repo,
             std::string ref,
             std::string repopath,
@@ -73,18 +71,17 @@ protected:
                    int depth);
     void index_files();
     void print_last_git_err_and_exit(int err);
-    void process_trees(int thread_id);
 
     code_searcher *cs_;
-    std::string submodule_prefix_;
     const google::protobuf::RepeatedPtrField<RepoSpec>& repositories_to_index_;
     const int repositories_to_index_length_;
     bool mode_singlethreaded_;
+    std::vector<std::thread> threads_;
+    thread_queue<tree_to_walk*> trees_to_walk_;
+
     std::mutex files_mutex_;
     std::vector<pre_indexed_file*> files_to_index_;
     std::vector<git_repository *> open_git_repos_;
-    std::vector<std::thread> threads_;
-    thread_queue<tree_to_walk*> trees_to_walk_;
 };
 
 #endif

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -54,17 +54,17 @@ public:
 protected:
     void process_trees();
     void walk(git_repository *curr_repo,
-            std::string ref,
-            std::string repopath,
-            std::string name,
+            const std::string& ref,
+            const std::string& repopath,
+            const std::string& name,
             Metadata metadata,
             bool walk_submodules,
-            std::string submodule_prefix);
-    void walk_tree(std::string pfx,
-                   std::string order,
-                   std::string repopath,
+            const std::string& submodule_prefix);
+    void walk_tree(const std::string& pfx,
+                   const std::string& order,
+                   const std::string& repopath,
                    bool walk_submodules,
-                   std::string submodule_prefix,
+                   const std::string& submodule_prefix,
                    const indexed_tree *idx_tree,
                    git_tree *tree,
                    git_repository *curr_repo,

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -24,10 +24,9 @@ struct pre_indexed_file {
     const indexed_tree *tree;
     std::string  repopath;
     std::string  path;
-    /* std::string id; // string version of git oid */
     int score;
     git_repository *repo;
-    git_object *obj;
+    git_blob *blob;
 };
 
 class git_indexer {
@@ -39,19 +38,21 @@ public:
 protected:
     void walk(git_repository *curr_repo,
             const std::string& ref,
-            const std::string repopath,
+            const std::string& repopath,
             const std::string& name,
             Metadata metadata,
             bool walk_submodules,
-            const std::string& submodule_prefix);
+            const std::string& submodule_prefix,
+            std::vector<pre_indexed_file>& results);
     void walk_tree(const std::string& pfx,
                    const std::string& order,
-                   const std::string repopath,
+                   const std::string& repopath,
                    bool walk_submodules,
                    const std::string& submodule_prefix,
                    const indexed_tree *idx_tree,
                    git_tree *tree,
-                   git_repository *curr_repo);
+                   git_repository *curr_repo,
+                   std::vector<pre_indexed_file>& results);
     void index_files();
     void print_last_git_err_and_exit(int err);
     void walk_repositories_subset(int start, int end, threadsafe_progress_indicator *tpi);
@@ -62,7 +63,6 @@ protected:
     std::vector<pre_indexed_file> files_to_index_;
     std::mutex files_mutex_;
     std::vector<std::thread> threads_;
-    per_thread<vector<pre_indexed_file>> files_to_index_local;
 };
 
 #endif

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -36,6 +36,8 @@ public:
     ~git_indexer();
     void begin_indexing();
 protected:
+    int get_next_repo_idx();
+    void process_repos(threadsafe_progress_indicator *tpi);
     void walk(git_repository *curr_repo,
             const std::string& ref,
             const std::string& repopath,

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -12,6 +12,7 @@
 #include "src/proto/config.pb.h"
 #include "src/smart_git.h"
 #include "src/lib/per_thread.h"
+#include "src/lib/threadsafe_progress_indicator.h"
 
 class code_searcher;
 class git_repository;
@@ -21,10 +22,10 @@ struct indexed_tree;
 // This should be enough to recover a file/bob from a repo
 struct pre_indexed_file {
     const indexed_tree *tree;
-     std::string  repopath;
-     std::string  path;
-     std::string id; // string version of git oid
-     int score;
+    std::string  repopath;
+    std::string  path;
+    std::string id; // string version of git oid
+    int score;
 };
 
 class git_indexer {
@@ -51,7 +52,7 @@ protected:
                    git_repository *curr_repo);
     void index_files();
     void print_last_git_err_and_exit(int err);
-    void walk_repositories_subset(int start, int end);
+    void walk_repositories_subset(int start, int end, threadsafe_progress_indicator *tpi);
 
     code_searcher *cs_;
     std::string submodule_prefix_;

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -43,7 +43,7 @@ protected:
             Metadata metadata,
             bool walk_submodules,
             const std::string& submodule_prefix,
-            std::vector<pre_indexed_file>& results);
+            std::vector<std::unique_ptr<pre_indexed_file>>& results);
     void walk_tree(const std::string& pfx,
                    const std::string& order,
                    const std::string& repopath,
@@ -52,7 +52,7 @@ protected:
                    const indexed_tree *idx_tree,
                    git_tree *tree,
                    git_repository *curr_repo,
-                   std::vector<pre_indexed_file>& results);
+                   std::vector<std::unique_ptr<pre_indexed_file>>& results);
     void index_files();
     void print_last_git_err_and_exit(int err);
     void walk_repositories_subset(int start, int end, threadsafe_progress_indicator *tpi);
@@ -60,7 +60,7 @@ protected:
     code_searcher *cs_;
     std::string submodule_prefix_;
     const google::protobuf::RepeatedPtrField<RepoSpec>& repositories_to_index_;
-    std::vector<pre_indexed_file> files_to_index_;
+    std::vector<std::unique_ptr<pre_indexed_file>> files_to_index_;
     std::mutex files_mutex_;
     std::vector<std::thread> threads_;
 };

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -24,7 +24,6 @@ struct pre_indexed_file {
     const indexed_tree *tree;
     std::string  repopath;
     std::string  path;
-    std::string id; // git oid
     std::unique_ptr<git_oid> oid;
     int score;
     git_repository *repo;

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -59,10 +59,10 @@ protected:
     code_searcher *cs_;
     std::string submodule_prefix_;
     const google::protobuf::RepeatedPtrField<RepoSpec>& repositories_to_index_;
-    std::vector<std::unique_ptr<pre_indexed_file>> files_to_index_;
+    std::vector<pre_indexed_file> files_to_index_;
     std::mutex files_mutex_;
     std::vector<std::thread> threads_;
-    per_thread<vector<std::unique_ptr<pre_indexed_file>>> files_to_index_local;
+    per_thread<vector<pre_indexed_file>> files_to_index_local;
 };
 
 #endif

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -22,7 +22,7 @@ struct pre_indexed_file {
     const indexed_tree *tree;
      std::string  repopath;
      std::string  path;
-     std::string id; // string version of oid
+     std::string id; // string version of git oid
      int score;
 };
 

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -24,7 +24,7 @@ struct pre_indexed_file {
     const indexed_tree *tree;
     std::string  repopath;
     std::string  path;
-    std::unique_ptr<git_oid> oid;
+    git_oid *oid;
     int score;
     git_repository *repo;
 };

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -10,25 +10,34 @@
 
 #include <string>
 #include "src/proto/config.pb.h"
+#include "src/smart_git.h"
 
 class code_searcher;
 class git_repository;
 class git_tree;
 struct indexed_tree;
 
+// This should be enough to recover a file/bob from a repo
+struct pre_indexed_file {
+    const indexed_tree *tree;
+     std::string  repopath;
+     std::string  path;
+     std::string id; // string version of oid
+     const unsigned char * id_test2;
+};
+
 class git_indexer {
 public:
     git_indexer(code_searcher *cs,
-                const std::string& repopath,
-                const std::string& name,
-                const Metadata &metadata,
-                bool walk_submodules);
+                const google::protobuf::RepeatedPtrField<RepoSpec>& repositories);
     ~git_indexer();
     void walk(const std::string& ref);
+    void begin_indexing();
 protected:
     void walk_tree(const std::string& pfx,
                    const std::string& order,
                    git_tree *tree);
+    void index_files();
 
     code_searcher *cs_;
     git_repository *repo_;
@@ -38,6 +47,8 @@ protected:
     Metadata metadata_;
     bool walk_submodules_;
     std::string submodule_prefix_;
+    const google::protobuf::RepeatedPtrField<RepoSpec>& repositories_to_index_;
+    std::vector<std::unique_ptr<pre_indexed_file>> files_to_index_;
 };
 
 #endif

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -32,21 +32,26 @@ public:
     git_indexer(code_searcher *cs,
                 const google::protobuf::RepeatedPtrField<RepoSpec>& repositories);
     ~git_indexer();
-    void walk(const std::string& ref);
+    void walk(git_repository *curr_repo,
+            const std::string& ref,
+            const std::string repopath,
+            const std::string& name,
+            Metadata metadata,
+            bool walk_submodules,
+            const std::string& submodule_prefix);
     void begin_indexing();
 protected:
     void walk_tree(const std::string& pfx,
                    const std::string& order,
-                   git_tree *tree);
+                   const std::string repopath,
+                   bool walk_submodules,
+                   const std::string& submodule_prefix,
+                   const indexed_tree *idx_tree,
+                   git_tree *tree,
+                   git_repository *curr_repo);
     void index_files();
 
     code_searcher *cs_;
-    git_repository *repo_;
-    const indexed_tree *idx_tree_;
-    std::string repopath_;
-    std::string name_;
-    Metadata metadata_;
-    bool walk_submodules_;
     std::string submodule_prefix_;
     const google::protobuf::RepeatedPtrField<RepoSpec>& repositories_to_index_;
     std::vector<std::unique_ptr<pre_indexed_file>> files_to_index_;

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -11,6 +11,7 @@
 #include <string>
 #include "src/proto/config.pb.h"
 #include "src/smart_git.h"
+#include "src/lib/per_thread.h"
 
 class code_searcher;
 class git_repository;
@@ -56,7 +57,9 @@ protected:
     std::string submodule_prefix_;
     const google::protobuf::RepeatedPtrField<RepoSpec>& repositories_to_index_;
     std::vector<std::unique_ptr<pre_indexed_file>> files_to_index_;
+    std::mutex files_mutex_;
     std::vector<std::thread> threads_;
+    per_thread<vector<std::unique_ptr<pre_indexed_file>>> files_to_index_local;
 };
 
 #endif

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -50,7 +50,7 @@ public:
     git_indexer(code_searcher *cs,
                 const google::protobuf::RepeatedPtrField<RepoSpec>& repositories);
     ~git_indexer();
-    void begin_indexing();
+    void index_repos();
 protected:
     void process_trees();
     void walk(git_repository *curr_repo,
@@ -71,11 +71,12 @@ protected:
                    int depth);
     void index_files();
     void print_last_git_err_and_exit(int err);
+    int get_num_threads_to_use();
 
     code_searcher *cs_;
     const google::protobuf::RepeatedPtrField<RepoSpec>& repositories_to_index_;
     const int repositories_to_index_length_;
-    bool mode_singlethreaded_;
+    bool is_singlethreaded_;
     std::vector<std::thread> threads_;
     thread_queue<tree_to_walk*> trees_to_walk_;
 

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -24,8 +24,10 @@ struct pre_indexed_file {
     const indexed_tree *tree;
     std::string  repopath;
     std::string  path;
-    std::string id; // string version of git oid
+    /* std::string id; // string version of git oid */
     int score;
+    git_repository *repo;
+    git_object *obj;
 };
 
 class git_indexer {

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -50,11 +50,13 @@ protected:
                    git_repository *curr_repo);
     void index_files();
     void print_last_git_err_and_exit(int err);
+    void walk_repositories_subset(int start, int end);
 
     code_searcher *cs_;
     std::string submodule_prefix_;
     const google::protobuf::RepeatedPtrField<RepoSpec>& repositories_to_index_;
     std::vector<std::unique_ptr<pre_indexed_file>> files_to_index_;
+    std::vector<std::thread> threads_;
 };
 
 #endif

--- a/src/git_indexer.h
+++ b/src/git_indexer.h
@@ -61,9 +61,11 @@ protected:
     code_searcher *cs_;
     std::string submodule_prefix_;
     const google::protobuf::RepeatedPtrField<RepoSpec>& repositories_to_index_;
+    const int repositories_to_index_length_;
+    std::atomic<int> next_repo_to_process_idx_{0};
+    std::mutex files_mutex_;
     std::vector<std::unique_ptr<pre_indexed_file>> files_to_index_;
     std::vector<git_repository *> open_git_repos_;
-    std::mutex files_mutex_;
     std::vector<std::thread> threads_;
 };
 

--- a/src/lib/BUILD
+++ b/src/lib/BUILD
@@ -4,6 +4,7 @@ cc_library(
         "debug.cc",
         "metrics.cc",
         "radix_sort.cc",
+        "rlimits.cc",
     ] + select({
         "@bazel_tools//src/conditions:linux_x86_64": ["fs_linux.cc"],
         "//conditions:default": ["fs_default.cc"],

--- a/src/lib/rlimits.cc
+++ b/src/lib/rlimits.cc
@@ -36,7 +36,7 @@ void increaseOpenFileLimitToMax() {
         uint32_t real_limit;
         size_t len = sizeof(real_limit);
         if (sysctlbyname("kern.maxfilesperproc", &real_limit, &len, nullptr, 0) != 0) {
-            fprintf(stderr, "failed to get sysctlbyname('kern.maxfilesperproc'). Can't bumpt open file descriptors\n");
+            fprintf(stderr, "failed to get sysctlbyname('kern.maxfilesperproc'). Can't bump open file descriptors\n");
             return;
         }
 

--- a/src/lib/rlimits.cc
+++ b/src/lib/rlimits.cc
@@ -40,7 +40,7 @@ void increaseOpenFileLimitToMax() {
             return;
         }
 
-        l.rlim_max = limit;
+        l.rlim_max = real_limit;
     }
 #endif
 

--- a/src/lib/rlimits.cc
+++ b/src/lib/rlimits.cc
@@ -1,0 +1,56 @@
+/********************************************************************
+ * livegrep -- rlimits.cc
+ * Copyright (c) 2022 Rodrigo Silva Mendoza
+ *
+ * This program is free software. You may use, redistribute, and/or
+ * modify it under the terms listed in the COPYING file.
+ ********************************************************************/
+#include "rlimits.h"
+
+#include <stdio.h>
+#include <sys/resource.h>
+#include <sys/types.h>
+
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
+
+// When indexing repos, in multithreaded mode we may bump up against most soft
+// limits. Especially on macOS, which has an insanely low soft limit of 256.
+// To work around this, we increase the current processes (codesearch's) soft limit 
+// up to the system/user defined hard limit. This may be wasteful, and in the
+// future we may want to cap this at say, 10000 or something.
+void increaseOpenFileLimitToMax() {
+    struct rlimit l;
+
+    if (getrlimit(RLIMIT_NOFILE, &l) != 0) {
+        fprintf(stderr, "failed to get RLIMIT_NOFILE. Can't bump max open file descriptors.\n");
+        return;
+    }
+
+#if defined(__APPLE__)
+    // macOS getrlimit sometimes lies, telling us the max is RLIM_INFINITY. In
+    // that case, we reach out to sysctlbyname, which gives an accurate max.
+
+    if (l.rlim_max == RLIM_INFINITY) {
+        uint32_t real_limit;
+        size_t len = sizeof(real_limit);
+        if (sysctlbyname("kern.maxfilesperproc", &real_limit, &len, nullptr, 0) != 0) {
+            fprintf(stderr, "failed to get sysctlbyname('kern.maxfilesperproc'). Can't bumpt open file descriptors\n");
+            return;
+        }
+
+        l.rlim_max = limit;
+    }
+#endif
+
+    if (l.rlim_cur >= l.rlim_max) {
+        return;
+    }
+
+    fprintf(stderr, "raising process file descriptors from %lu to %lu\n", l.rlim_cur, l.rlim_max);
+    l.rlim_cur = l.rlim_max;
+    if (setrlimit(RLIMIT_NOFILE, &l) != 0) {
+        fprintf(stderr, "failed to bump file descriptors\n");
+    }
+}

--- a/src/lib/rlimits.h
+++ b/src/lib/rlimits.h
@@ -1,17 +1,13 @@
 /********************************************************************
- * livegrep -- rlimit.h
+ * livegrep -- rlimits.h
  * Copyright (c) 2022 Rodrigo Silva Mendoza
  *
  * This program is free software. You may use, redistribute, and/or
  * modify it under the terms listed in the COPYING file.
  ********************************************************************/
-#ifndef CODESEARCH_SCORE_H
-#define CODESEARCH_SCORE_H
+#ifndef CODESEARCH_RLIMITS_H
+#define CODESEARCH_RLIMITS_H
 
-#include <string>
-
-using std::string;
-
-int score_file(const string& file_path);
+void increaseOpenFileLimitToMax();
 
 #endif

--- a/src/lib/thread_queue.h
+++ b/src/lib/thread_queue.h
@@ -49,6 +49,11 @@ public:
         return true;
     }
 
+    size_t size() {
+        std::unique_lock<std::mutex> locked(mutex_);
+        return queue_.size();
+    }
+
  protected:
     thread_queue(const thread_queue&);
     thread_queue operator=(const thread_queue &);

--- a/src/lib/threadsafe_progress_indicator.h
+++ b/src/lib/threadsafe_progress_indicator.h
@@ -1,0 +1,48 @@
+#ifndef CODESEARCH_THREADSAFE_PROGRESS_INDICATOR
+#define CODESEARCH_THREADSAFE_PROGRESS_INDICATOR
+
+#include <atomic>
+#include <mutex>
+#include <iostream>
+#include <cmath>
+
+class threadsafe_progress_indicator {
+    public:
+        threadsafe_progress_indicator(float work_todo, 
+                                      const char * prefix, const char * done_suffix_)
+        : work_todo_(work_todo), work_done_(0), prefix_(prefix), done_suffix_(done_suffix_), wrote_done_suffix_(false) {
+        }
+
+        void tick(std::ostream &os = std::cout) {
+            // raise an error if we're ticking more than done?
+            std::lock_guard<std::mutex> guard(mutex_);
+            work_done_++;
+
+            if (work_todo_ == work_done_ && wrote_done_suffix_) return;
+
+            os << "\r" << std::flush;
+
+            os << prefix_;
+
+            float percent_done = std::round((work_done_ / work_todo_) * 100);
+
+            os << " " << percent_done << "% - [" 
+                << work_done_ << "/" << work_todo_ << "]";
+
+            if (work_todo_ == work_done_) {
+                os << " " << done_suffix_ << "\n";
+                wrote_done_suffix_ = true;
+                os << std::flush;
+            }
+        }
+
+    private:
+        std::mutex mutex_;
+        float work_todo_;
+        float work_done_;
+        const char * prefix_;
+        const char * done_suffix_;
+        bool wrote_done_suffix_;
+};
+
+#endif

--- a/src/lib/threadsafe_progress_indicator.h
+++ b/src/lib/threadsafe_progress_indicator.h
@@ -30,7 +30,7 @@ class threadsafe_progress_indicator {
                 << work_done_ << "/" << work_todo_ << "]";
 
             if (work_todo_ == work_done_) {
-                os << " " << done_suffix_ << "\n";
+                os << "\n" << "    " << done_suffix_ << "\n";
                 wrote_done_suffix_ = true;
                 os << std::flush;
             }

--- a/src/score.cc
+++ b/src/score.cc
@@ -47,8 +47,9 @@ int score_file(string file_path) {
     //    Also, this requires "reading" all of the content of all
     //    files to be indexed before-hand, which will turn into a scale/compute
     //    problem when using this on a large enough number of repos.
-    // 2. What else? Zoekt uses file content length, but that seems a mistake
-    // 3. Number of ctags files? Don't yet have ctags however.
+    // 2. What else? Zoekt uses file content length and file name, but with our
+    //    absence of ctags symbols, that might skew results too much.
+    // 3. Number of ctags symbols? Don't yet have ctags however.
 
     return starting_score;
 }

--- a/src/score.cc
+++ b/src/score.cc
@@ -5,20 +5,19 @@
 
 #include "re2/re2.h"
 
-#include "src/rank.h"
+#include "src/score.h"
 
 using re2::RE2;
 using std::string;
 
-static RE2 generated_re("min.js|js.map|_pb2");
-static RE2 vendor_re("(node_modules|vendor|vendor|github.com|third_party)\\/");
+static RE2 generated_re("min\\.js|js\\.map|_pb2|generated|\\/minified\\/|bundle\\.");
+static RE2 vendor_re("(node_modules|vendor||github.com|third_party|thirdparty)\\/");
 static RE2 test_re("test");
+static RE2 misc_re("package-lock.json");
 
 // We use file_path so we can downrank anything under, say, vendor/*
 // or test/*
-int rank_file(string file_path) {
-    fprintf(stdout, "in rank_file: %s\n", file_path.c_str());
-
+int score_file(string file_path) {
     int starting_score = 0;
 
     // Check if this is generated code
@@ -36,17 +35,21 @@ int rank_file(string file_path) {
         starting_score -= 50;
     }
 
+    if (RE2::PartialMatch(file_path, misc_re)) {
+        starting_score -= 50;
+    }
+
+    
     // Positively ranking a file is much harder. Some ideas
-    // 1. Promote files that have many references to that file
+    // 1. Promote files that have many references to that file. E.g PageRank.
     //    This would be difficult to do with regex statements
-    //    for the many types of imports that are possible. We could
-    //    start slowly with Go files for example, and go from there.
-    //    This may however result in Go files being ranked ahead of
-    //    other languages in the interim..
+    //    for the many types of imports that are possible.
+    //    Also, this requires "reading" all of the content of all
+    //    files to be indexed before-hand, which will turn into a scale/compute
+    //    problem when using this on a large enough number of repos.
     // 2. What else? Zoekt uses file content length, but that seems a mistake
     // 3. Number of ctags files? Don't yet have ctags however.
 
-    fprintf(stdout, "giving a score of: %f\n", starting_score);
     return starting_score;
 }
 

--- a/src/score.cc
+++ b/src/score.cc
@@ -17,7 +17,7 @@ static RE2 misc_re("package-lock.json");
 
 // We use file_path so we can downrank anything under, say, vendor/*
 // or test/*
-int score_file(string file_path) {
+int score_file(const string& file_path) {
     int starting_score = 0;
 
     // Check if this is generated code

--- a/src/score.cc
+++ b/src/score.cc
@@ -11,7 +11,7 @@ using re2::RE2;
 using std::string;
 
 static RE2 generated_re("min\\.(js|css)|js\\.map|_pb2\\/|generated|minified|bundle\\.|package-lock\\.json|yarn\\.lock|go\\.sum");
-static RE2 vendor_re("(node_modules|vendor|github.com|third_party|thirdparty)\\/");
+static RE2 vendor_re("(node_modules|vendor|github.com|third_party|thirdparty|external)\\/");
 static RE2 test_re("test|\\.spec\\.jsx");
 
 int score_file(const string& file_path) {

--- a/src/score.cc
+++ b/src/score.cc
@@ -10,13 +10,10 @@
 using re2::RE2;
 using std::string;
 
-static RE2 generated_re("min\\.js|js\\.map|_pb2|generated|\\/minified\\/|bundle\\.");
-static RE2 vendor_re("(node_modules|vendor||github.com|third_party|thirdparty)\\/");
-static RE2 test_re("test");
-static RE2 misc_re("package-lock.json");
+static RE2 generated_re("min\\.(js|css)|js\\.map|_pb2\\/|generated|minified|bundle\\.|package-lock\\.json|yarn\\.lock|go\\.sum");
+static RE2 vendor_re("(node_modules|vendor|github.com|third_party|thirdparty)\\/");
+static RE2 test_re("test|\\.spec\\.jsx");
 
-// We use file_path so we can downrank anything under, say, vendor/*
-// or test/*
 int score_file(const string& file_path) {
     int starting_score = 0;
 
@@ -35,11 +32,6 @@ int score_file(const string& file_path) {
         starting_score -= 50;
     }
 
-    if (RE2::PartialMatch(file_path, misc_re)) {
-        starting_score -= 50;
-    }
-
-    
     // Positively ranking a file is much harder. Some ideas
     // 1. Promote files that have many references to that file. E.g PageRank.
     //    This would be difficult to do with regex statements

--- a/src/score.cc
+++ b/src/score.cc
@@ -1,3 +1,10 @@
+/********************************************************************
+ * livegrep -- score.cc
+ * Copyright (c) 2022 Rodrigo Silva Mendoza
+ *
+ * This program is free software. You may use, redistribute, and/or
+ * modify it under the terms listed in the COPYING file.
+ ********************************************************************/
 #include <stdio.h>
 #include <string.h>
 

--- a/src/score.cc
+++ b/src/score.cc
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <string>
+
+#include "re2/re2.h"
+
+#include "src/rank.h"
+
+using re2::RE2;
+using std::string;
+
+static RE2 generated_re("min.js|js.map|_pb2");
+static RE2 vendor_re("(node_modules|vendor|vendor|github.com|third_party)\\/");
+static RE2 test_re("test");
+
+// We use file_path so we can downrank anything under, say, vendor/*
+// or test/*
+int rank_file(string file_path) {
+    fprintf(stdout, "in rank_file: %s\n", file_path.c_str());
+
+    int starting_score = 0;
+
+    // Check if this is generated code
+    if (RE2::PartialMatch(file_path, generated_re)) {
+        starting_score -= 100;
+    }
+
+    // Check if this is vendor/third_part code
+    if (RE2::PartialMatch(file_path, vendor_re)) {
+        starting_score -= 100;
+    }
+    
+    // Check if this is test code
+    if (RE2::PartialMatch(file_path, test_re)) {
+        starting_score -= 50;
+    }
+
+    // Positively ranking a file is much harder. Some ideas
+    // 1. Promote files that have many references to that file
+    //    This would be difficult to do with regex statements
+    //    for the many types of imports that are possible. We could
+    //    start slowly with Go files for example, and go from there.
+    //    This may however result in Go files being ranked ahead of
+    //    other languages in the interim..
+    // 2. What else? Zoekt uses file content length, but that seems a mistake
+    // 3. Number of ctags files? Don't yet have ctags however.
+
+    fprintf(stdout, "giving a score of: %f\n", starting_score);
+    return starting_score;
+}
+
+

--- a/src/score.h
+++ b/src/score.h
@@ -4,4 +4,4 @@
 
 using std::string;
 
-int rank_file(string file_path);
+int score_file(string file_path);

--- a/src/score.h
+++ b/src/score.h
@@ -4,4 +4,4 @@
 
 using std::string;
 
-int score_file(string file_path);
+int score_file(const string& file_path);

--- a/src/score.h
+++ b/src/score.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <string>
+
+using std::string;
+
+int rank_file(string file_path);

--- a/src/score.h
+++ b/src/score.h
@@ -1,5 +1,5 @@
 /********************************************************************
- * livegrep -- rlimit.h
+ * livegrep -- score.h
  * Copyright (c) 2022 Rodrigo Silva Mendoza
  *
  * This program is free software. You may use, redistribute, and/or

--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -108,7 +108,7 @@ void build_index(code_searcher *cs, const vector<std::string> &argv) {
     }
 
         git_indexer g_indexer(cs, spec.repositories());
-        g_indexer.begin_indexing();
+        g_indexer.index_repos();
 }
 
 void initialize_search(code_searcher *search,

--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -107,16 +107,18 @@ void build_index(code_searcher *cs, const vector<std::string> &argv) {
         fprintf(stderr, "done\n");
     }
 
-    for (auto &repo  : spec.repositories()) {
-        fprintf(stderr, "Walking repo_spec name=%s, path=%s (including  submodules: %s)\n",
-                repo.name().c_str(), repo.path().c_str(), repo.walk_submodules() ? "true" : "false");
-        git_indexer indexer(cs, repo.path(), repo.name(), repo.metadata(), repo.walk_submodules());
-        for (auto &rev : repo.revisions()) {
-            fprintf(stderr, "  walking %s\n", rev.c_str());
-            indexer.walk(rev);
-            fprintf(stderr, "  done\n");
-        }
-    }
+        git_indexer indexer(cs, spec.repositories());
+        indexer.begin_indexing();
+        fprintf(stderr, "after begin_indexing()\n");
+    /* for (auto &repo  : spec.repositories()) { */
+    /*     fprintf(stderr, "Walking repo_spec name=%s, path=%s (including  submodules: %s)\n", */
+    /*             repo.name().c_str(), repo.path().c_str(), repo.walk_submodules() ? "true" : "false"); */
+    /*     for (auto &rev : repo.revisions()) { */
+    /*         fprintf(stderr, "  walking %s\n", rev.c_str()); */
+    /*         indexer.walk(rev); */
+    /*         fprintf(stderr, "  done\n"); */
+    /*     } */
+    /* } */
 }
 
 void initialize_search(code_searcher *search,

--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -107,18 +107,8 @@ void build_index(code_searcher *cs, const vector<std::string> &argv) {
         fprintf(stderr, "done\n");
     }
 
-        git_indexer indexer(cs, spec.repositories());
-        indexer.begin_indexing();
-        fprintf(stderr, "after begin_indexing()\n");
-    /* for (auto &repo  : spec.repositories()) { */
-    /*     fprintf(stderr, "Walking repo_spec name=%s, path=%s (including  submodules: %s)\n", */
-    /*             repo.name().c_str(), repo.path().c_str(), repo.walk_submodules() ? "true" : "false"); */
-    /*     for (auto &rev : repo.revisions()) { */
-    /*         fprintf(stderr, "  walking %s\n", rev.c_str()); */
-    /*         indexer.walk(rev); */
-    /*         fprintf(stderr, "  done\n"); */
-    /*     } */
-    /* } */
+        git_indexer g_indexer(cs, spec.repositories());
+        g_indexer.begin_indexing();
 }
 
 void initialize_search(code_searcher *search,

--- a/test/BUILD
+++ b/test/BUILD
@@ -11,6 +11,7 @@ cc_test(
         "main.cc",
         "planner_test.cc",
         "tagsearch_test.cc",
+        "score_test.cc",
     ],
     defines = select({
         ":darwin": [

--- a/test/score_test.cc
+++ b/test/score_test.cc
@@ -30,6 +30,7 @@ TEST(ScoreTest, ScoresFilesAsExpected) {
         {"github.com/cloud.google.com/go/iam/iam.go", -100},
         {"third_party/BUILD.divsufsort", -100},
         {"thirdparty/BUILD.divsufsort", -100},
+        {"external/libgit2/s.c", -100},
 
         // test code
         {"client/test/BUILD", -50},

--- a/test/score_test.cc
+++ b/test/score_test.cc
@@ -1,0 +1,62 @@
+#include <string.h>
+#include "gtest/gtest.h"
+
+#include "src/score.h"
+
+TEST(ScoreTest, ScoresFilesAsExpected) {
+    std::vector< std::pair<std::string, int>> testcases = {
+
+        // machine generated
+        {"web/htdocs/assets/3d/bootstrap.min.css", -100},
+        {"web/htdocs/assets/3d/bootstrap.min.js", -100},
+        {"web/htdocs/assets/3d/bootstrap.js.map", -100},
+        {"web/htdocs/assets/bundle.js", -100},
+        {"web/htdocs/assets/bundle.jsx", -100},
+        {"src/_pb2/types.proto", -100},
+        {"web/htdocs/assets/generated/cool-file.js", -100},
+        {"web/htdocs/assets/cool-generated-file.js", -100},
+        {"web/htdocs/assets/abcd.minified.js", -100},
+        {"web/htdocs/assets/minified/README.txt", -100},
+        {"src/minified_card.cpp", -100},
+        {"tunnel.minified.php", -100},
+        {"package-lock.json", -100},
+        {"yarn.lock", -100},
+        {"go.sum", -100},
+
+        // vendored or third_party
+        {"web/node_modules/folder/file.js", -100},
+        {"web/node_modules/folder/folder/file2.js", -100},
+        {"vendor/cloud.google.com/go/iam/iam.go", -100},
+        {"github.com/cloud.google.com/go/iam/iam.go", -100},
+        {"third_party/BUILD.divsufsort", -100},
+        {"thirdparty/BUILD.divsufsort", -100},
+
+        // test code
+        {"client/test/BUILD", -50},
+        {"client/test/suites/benchmarks", -50},
+        {"__tests__/something.jsx", -50},
+        {"src/some-test.jsx", -50},
+        {"src/something.spec.jsx", -50},
+
+        // vendored/third_party test code
+        {"web/node_modules/__tests__/x.js", -150},
+
+        // machine generated test code
+        {"web/generated/test.js", -150},
+
+        // files that should not be downranked
+        // e.g. - not machine generated, not vendor/third_party code and not
+        // tests
+        {"README.md", 0},
+        {"src/lib/fs.h", 0},
+        {"src/codesearch.cc", 0},
+        {"server/api/types.go", 0},
+        {"src/proto/config.proto", 0},
+        {"cmd/livegrep-fetch-reindex/main.go", 0},
+        {"docker/base/Dockerfile", 0},
+    };
+
+    for (auto it = testcases.begin(); it != testcases.end(); ++it) {
+        EXPECT_TRUE(it->second == score_file(it->first)) << "unexpected score for : " << it->first;
+    }
+}


### PR DESCRIPTION
Hello! 

This PR introduces a way to improve search results, by scoring and ranking files prior to indexing, so that more "annoying" files get indexed last and so generally show last in search results. 

The idea works really well! On both MB and GB scale corpora, the down-ranked files show at the bottom of search results, or don't show at all until `max_matches` is extended. Indexing performance is generally a bit faster than before, more on that below.

We take the following steps:
1. We walk all repos/files before indexing them. While walking, we give each file/blob a score.
2. We sort the list of all files based on score (and, in the multi-threaded case, by repo name as well)
3. We then walk the sorted list, and call `cs->index_file` to actually index the file.

## Performance 
We're now generally faster at indexing than before. The speedup is greater when there are more git repos to index, thanks to a multi-threaded filesystem walk described below. Most of the time the speedup is within a few seconds. Here's a comparison run:
```
$ (score-and-rank) ./bazel-bin/src/tools/codesearch -index-only -dump-index nelhage.idx ./repos/nelhage.json
...
repository indexed in 159.871761s
== begin metrics ==
index.bytes 1716122017
index.bytes.dedup 1421882081
index.content.chunks 113
index.content.ranges 38506740
index.data.chunks 11
index.files 124302
index.lines 44171401
index.lines.dedup 29077802
== end metrics ==

$ (main) ./bazel-bin/src/tools/codesearch -index-only -dump-index nelhage.idx ./repos/nelhage.json
...
repository indexed in 163.871761s
== begin metrics ==
index.bytes 1716122017
index.bytes.dedup 1421882081
index.content.chunks 113
index.content.ranges 38506740
index.data.chunks 11
index.files 124302
index.lines 44171401
index.lines.dedup 29077802
== end metrics ==
```

I've used `hyperfine` to test performance with multiple runs and with/without warmups and caches, and this assertion (we're now faster) generally holds.

## Multi-threading

We use multiple threads to walk the git trees within a repo. We don't have each thread tackle a single git repo, instead, while walking repos we push each root tree/directory to a `thread_queue` that some workers work off of. This turned out to be faster than each each thread taking a repo at a time. I'm fairly sure this is because workloads are now more balanced, instead of a single thread being stuck indexing a huge repo, multiple threads at a time can help out with said huge repos trees.

Users can opt out of multi-threading, and we ourselves opt out if there aren't enough repos to index, as generally the time it takes to open the threads dominates indexing time with small workloads. We also opt out if the `FLAGS_order_root` flag is on, since a specific ordering isn't really easy to do when walking with multiple threads.

## Memory
I've run this through valgrind and don't see any memory leaks.
```
==330891== LEAK SUMMARY:
==330891==    definitely lost: 0 bytes in 0 blocks
==330891==    indirectly lost: 0 bytes in 0 blocks
==330891==      possibly lost: 0 bytes in 0 blocks
==330891==    still reachable: 91,554 bytes in 1,287 blocks
==330891==         suppressed: 0 bytes in 0 blocks
```

The number of reachable blocks is consistent with valgrind output for previous indexer versions.

Also, as far as I can tell, memory usage is consistent with prior versions.

## Random thoughts
* I couldn't find a way I was happy with to positively boost files. There are comments in `src/score.cc` about that.
* I've done my best with logging, which got harder with having multiple threads. I'm pretty happy with where it ended up though, try an indexing run and let me know what you think.
* We're pretty IO bound now, since we're efficiently using a machines core's to walk repos, we're bound by the disk access speeds to read blobs and odb info.
* I've added functionality to bump the number of file descriptors the process can have open. This is pretty necessary on macOS, where the default soft limit is 256. Users can opt out. They can't opt in and specify a max, we auto bump to the systems hard limit. That might be a nice thing to add in.
* At the moment, users can opt out of threads completely, but can't choose thread count. Would be fairly easy to add in, might be nice
* Sorting search results like in #111 would be a great next thing, when/if this change lands.
* I didn't add functionality to opt out of scoring/ranking. Might be nice to add in.
* It was faster to use a mutex and push to the global list of files than for each thread to keep a local list and then push once it's done. That surprised me, I figured contention might be an issue, but I guess not.
* The most expensive thing we really do is `git_blob_lookup` and `git_tree_entry_to_object`. There's no way I can to keep the blobs in memory - so we don't have to do lookups twice - without ballooning our memory usage to a huge amount. When I tried keeping the blobs in memory, indexing was almost twice as fast, like 10mins vs 19mins on 5000 repos, so there may be a "high performance" version we can chase that keeps a bounded cache of git_blobs. Unbounded is probably a no go, on those 5000 repos codesearch was using like 50GB of ram during indexing.


This is my first time ever writing C++, so apologies for the rough spots!

Anything at all let me know, happy to change things around.

*note, build is failing atm (but shouldn't be), I think it's because I committed a few too many times within an hour and the connection to the remote cache has been hit with too many requests recently. Will re-trigger it tomorrow. On that note, on my fork I've got a system like your initial one using github caches, that works super well for a fast commit pace, I can upstream that if you'd like.