### PR TITLE
Update mirrored git clones when remote HEAD changes

### DIFF
--- a/cmd/livegrep-fetch-reindex/BUILD
+++ b/cmd/livegrep-fetch-reindex/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//src/proto:go_config_proto",
         "//src/proto:go_proto",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )
 

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -32,7 +32,7 @@ var (
 	flagStatsdOn      = flag.Bool("send-metrics-to-statsd", false, "Send indexing metrics to StatsD")
 	flagStatsdAddr    = flag.String("statsd-address", "", "address URI of statsd listener for metrics export")
 	flagStatsdPrefix  = flag.String("statsd-prefix", "", "optional prefix to apply to all metrics")
-	flagUpdateHead    = flag.Bool("update-head", true, "update the HEAD reference if it has changed on remote")
+	flagUpdateHead    = flag.Bool("update-head", true, "update the local HEAD ref if it is different than remote. Done when updating already cloned repos.")
 )
 
 // Used to extract the refname from a line like the following:

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -279,8 +279,7 @@ func checkoutOne(r *config.RepoSpec) error {
 			args = append(args, fmt.Sprintf("--depth=%d", r.CloneOptions.Depth))
 		}
 		args = append(args, remote, r.Path)
-		err = callGit("git", args, username, password)
-		return err
+		return callGit("git", args, username, password)
 	}
 
 	if err := exec.Command("git", "-C", r.Path, "remote", "set-url", "origin", remote).Run(); err != nil {

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -28,10 +28,6 @@ var (
 	flagReloadBackend = flag.String("reload-backend", "", "Backend to send a Reload RPC to")
 	flagNumWorkers    = flag.Int("num-workers", 8, "Number of workers used to update repositories")
 	flagNoIndex       = flag.Bool("no-index", false, "Skip indexing after fetching")
-	flagMetricsPath   = flag.String("metrics-out", "", "File that indexing metrics should be sent to")
-	flagStatsdOn      = flag.Bool("send-metrics-to-statsd", false, "Send indexing metrics to StatsD")
-	flagStatsdAddr    = flag.String("statsd-address", "", "address URI of statsd listener for metrics export")
-	flagStatsdPrefix  = flag.String("statsd-prefix", "", "optional prefix to apply to all metrics")
 	flagUpdateHead    = flag.Bool("update-head", true, "update the local HEAD ref if it is different than remote. Done when updating already cloned repos.")
 )
 

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -187,7 +187,7 @@ func callGetGetOutput(program string, args []string, username string, password s
 
 // calls cmd.Run() if returnOutput is false
 // and cmd.Output() otherwise
-// always returns an out []byte, but it will always be nill if returnOutput is false
+// always returns an out []byte, but it will always be nil if returnOutput is false
 func callGitInternal(program string, args []string, username string, password string, returnOutput bool) ([]byte, error) {
 	var err error
 	var out []byte
@@ -303,7 +303,7 @@ func checkoutOne(r *config.RepoSpec) error {
 	// 3. Compare them. If outdated, update the local to match remote - (git symbolic-ref HEAD new_ref)
 	// We use goroutines to call `git fetch -p` and `git ls-remote --symref origin HEAD` in "parallel"
 	// becase they each take ~1.5s.
-	g := new(errgroup.Group)
+	var g errgroup.Group
 
 	var remoteOut []byte
 	var remoteErr error

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -35,11 +35,9 @@ var (
 	flagUpdateHead    = flag.Bool("update-head", true, "update the HEAD reference if it has changed on remote")
 )
 
-var (
-	// Uses to extract the refname from a line like the following:
-	// ref: refs/heads/good_main_2     HEAD
-	remoteHeadRefExtractorReg = regexp.MustCompile("ref:\\s*([^\\s]*)\\s*HEAD")
-)
+// Used to extract the refname from a line like the following:
+// ref: refs/heads/good_main_2     HEAD
+var remoteHeadRefExtractorReg = regexp.MustCompile("ref:\\s*([^\\s]*)\\s*HEAD")
 
 func main() {
 	flag.Parse()

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -28,7 +28,6 @@ var (
 	flagReloadBackend = flag.String("reload-backend", "", "Backend to send a Reload RPC to")
 	flagNumWorkers    = flag.Int("num-workers", 8, "Number of workers used to update repositories")
 	flagNoIndex       = flag.Bool("no-index", false, "Skip indexing after fetching")
-	flagUpdateHead    = flag.Bool("update-head", true, "update the local HEAD ref if it is different than remote. Done when updating already cloned repos.")
 )
 
 // Used to extract the refname from a line like the following:
@@ -278,12 +277,6 @@ func checkoutOne(r *config.RepoSpec) error {
 	args := []string{"--git-dir", r.Path, "fetch", "-p"}
 	if r.CloneOptions != nil && r.CloneOptions.Depth != 0 {
 		args = append(args, fmt.Sprintf("--depth=%d", r.CloneOptions.Depth))
-	}
-
-	// Call git-fetch and finish
-	if !(*flagUpdateHead) {
-		_, err = callGit("git", args, username, password, false)
-		return err
 	}
 
 	// We check and update (if needed) the HEAD ref to avoid scenarios where

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -50,6 +50,7 @@ var (
 	flagSkipMissing             = flag.Bool("skip-missing", false, "skip repositories where the specified revision is missing")
 	flagMaxConcurrentGHRequests = flag.Int("max-concurrent-gh-requests", 1, "Applied per org/user. If fetching 2 orgs, you will have 2x{yourInput} network calls possible at a time")
 	flagNoIndex                 = flag.Bool("no-index", false, "Skip indexing after writing config and fetching")
+	flagUpdateHead              = flag.Bool("update-head", true, "update the local HEAD ref if it is different than remote. Done when updating already cloned repos.")
 
 	flagRepos = stringList{}
 	flagOrgs  = stringList{}
@@ -156,6 +157,9 @@ func main() {
 	}
 	if *flagSkipMissing {
 		args = append(args, "--skip-missing")
+	}
+	if !(*flagUpdateHead) { // only include when false, since true by default
+		args = append(args, "--update-head=false")
 	}
 	args = append(args, configPath)
 

--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -50,7 +50,6 @@ var (
 	flagSkipMissing             = flag.Bool("skip-missing", false, "skip repositories where the specified revision is missing")
 	flagMaxConcurrentGHRequests = flag.Int("max-concurrent-gh-requests", 1, "Applied per org/user. If fetching 2 orgs, you will have 2x{yourInput} network calls possible at a time")
 	flagNoIndex                 = flag.Bool("no-index", false, "Skip indexing after writing config and fetching")
-	flagUpdateHead              = flag.Bool("update-head", true, "update the local HEAD ref if it is different than remote. Done when updating already cloned repos.")
 
 	flagRepos = stringList{}
 	flagOrgs  = stringList{}
@@ -157,9 +156,6 @@ func main() {
 	}
 	if *flagSkipMissing {
 		args = append(args, "--skip-missing")
-	}
-	if !(*flagUpdateHead) { // only include when false, since true by default
-		args = append(args, "--update-head=false")
 	}
 	args = append(args, configPath)
 

--- a/tools/build_defs/go_externals.bzl
+++ b/tools/build_defs/go_externals.bzl
@@ -39,6 +39,7 @@ _externals = [
     _golang_x("oauth2", "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"),
     _golang_x("sys", "33540a1f603772f9d4b761f416f5c10dade23e96"),
     _golang_x("crypto", "4b2356b1ed79e6be3deca3737a3db3d132d2847a"),
+    _golang_x("sync", "0de741cfad7ff3874b219dfbc1b9195b58c7c490"),
     struct(
         name = "org_golang_google_appengine",
         commit = "170382fa85b10b94728989dfcf6cc818b335c952",


### PR DESCRIPTION
Hello - this patch attempts to solve sync issues between the mirrored clones that `livegrep-github-reindex` creates and their upstream counterparts - described in #293. TLDR of that issue is that when changes are made to the HEAD refs of the remotes of locally cloned mirror repos,  `git fetch -p` will invalidate the current local HEAD, but won't update it to match the new remote HEAD, which  eventually leads livegrep to think that repo is empty when it's indexing, which causes it to be skipped.

To fix this, we make an extra call to git - `git ls-remote --symref origin HEAD`. We then compare the remote `HEAD` information to the local `HEAD`, and if different, then we manually update with `git symbolic-ref HEAD {newHead}`.

Even with the extra call to git, this patch doesn't slow down indexing runs. Updating even 5000 repos takes exactly the same amount of time it used to, thanks to the goroutines used for the `git fetch` and `git ls-remote` calls.

To test this, I ran `fetch-reindex`, then modified the default branch name for a few of the repos, then re-ran `fetch-reindex` and made sure that the patch picked up the modifications to the upstream. Example run:

```
$ bazel-bin/cmd/livegrep-fetch-reindex/livegrep-fetch-reindex_/livegrep-fetch-reindex -out=xvandish.idx repos/xvandish.json
$ // then I went to github and renamed the default branch of livegrep-fragment from `good_main_5` to `good_main_6`.
$ bazel-bin/cmd/livegrep-fetch-reindex/livegrep-fetch-reindex_/livegrep-fetch-reindex -out=xvandish.idx repos/xvandish.json
  ...
  From github.com:xvandish/livegrep-fragment
  - [deleted]         (none)     -> good_main_5
  * [new branch]      good_main_6 -> good_main_6
  xvandish/livegrep-fragment: remote HEAD: refs/heads/good_main_6 does not match local HEAD: refs/heads/good_main_5. Attempting to fix...
  xvandish/livegrep-fragment: HEAD update done.
  ...
```

I've also been running this on our company instance, and its successfully found and fixed the instances of this problem. 

Some random thoughts:
* eventually, `git remote set-head origin -a` may be able to do this (`ls-remote..` + `symbolic-ref..`) by itself. A patched version of git enables this, but who knows if/when it would make it upstream. See [this thread on the git mailing list I started](https://public-inbox.org/git/CANWRddMXrhs2grTfq9NtHM7KqxaFRejvaXxvDGV90_m=Kmm-uA@mail.gmail.com/) for more info. 
* I gated this functionality behind a (by default enabled) flag in the spirit of not making unexpected changes - but since this theoretically leads to more correct deployments than before, I think it also makes sense to not gate it at all.
* I modified `callGit` so that it could output to either `stdout/err` or a buffer, which adds some complexity. I'm not a huge fan of it, but I went with that over a copy paste `callGit2` version that does the exact same thing as `callGit` but prints to a buffer. Happy to change that if you prefer.

This closes #293 .