### PR TITLE
Skip updating empty repos

### DIFF
--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -326,7 +326,7 @@ func checkoutOne(r *config.RepoSpec) error {
 
 	// If there is no remote out, then we have an empty repository.
 	// We should skip and do nothing at this point
-	if remoteOut == nil || len(remoteOut) == 0 {
+	if len(remoteOut) == 0 {
 		log.Printf("Repository %s at %s is empty, skipping", r.Name, r.Path)
 		return nil
 	}


### PR DESCRIPTION
## The Problem

Recent changes relied on remoteOut existing from the command `git ls-remote --symref origin HEAD`. In the event it does not exist `remoteHeadRefExtractorReg.FindStringSubmatch(string(remoteOut))` will return no submatches and then throw an exception due to this snippet:
```golang
if len(submatches) == 1 {
    return errors.New("could not parse ls-remote --symref origin HEAD output")
}
remoteHead := strings.TrimSpace(submatches[1]) // this line throws an exception if `remoteOut` is empty
``` 

## How can this cause issues?

If you have an empty repo (e.g. something that was made but nothing was pushed) this will return nothing. This may not happen in smaller instances, but in larger orgs this can happen if people make a repo and forget about it. We have a couple of empty repos, and livegrep is currently broken for us.

## The fix

If the output is empty, simply return. I also snuck in what I assume is a typo `callGetGetOutput` => `callGetGitOutput`

cc @nelhage this fixes a bug introduced in https://github.com/livegrep/livegrep/pull/340