### PR TITLE
Update head ref patches

### DIFF
--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -324,15 +324,22 @@ func checkoutOne(r *config.RepoSpec) error {
 		return err
 	}
 
+	// Early check, if there's no remote HEAD we can't do anything
+	remoteOutClean := strings.TrimSpace(string(remoteOut))
+	if remoteOutClean == "" {
+		log.Printf("%s: Won't update HEAD. Empty `git ls-remote --symref origin HEAD` (empty repo?)\n", r.Name)
+		return nil
+	}
+
 	currHeadOut, err := exec.Command("git", "--git-dir", r.Path, "symbolic-ref", "HEAD").Output()
 	if err != nil {
 		return err
 	}
 	currHead := strings.TrimSpace(string(currHeadOut))
 
-	submatches := remoteHeadRefExtractorReg.FindStringSubmatch(string(remoteOut))
+	submatches := remoteHeadRefExtractorReg.FindStringSubmatch(remoteOutClean)
 	if len(submatches) < 2 {
-		return errors.New(fmt.Sprintf("%s: could not parse `ls-remote --symref origin HEAD` output: %s\n", r.Name, string(remoteOut)))
+		return errors.New(fmt.Sprintf("%s: could not parse `ls-remote --symref origin HEAD` output: %s\n", r.Name, remoteOutClean))
 	}
 	remoteHead := strings.TrimSpace(submatches[1])
 

--- a/cmd/livegrep-fetch-reindex/main.go
+++ b/cmd/livegrep-fetch-reindex/main.go
@@ -331,8 +331,8 @@ func checkoutOne(r *config.RepoSpec) error {
 	currHead := strings.TrimSpace(string(currHeadOut))
 
 	submatches := remoteHeadRefExtractorReg.FindStringSubmatch(string(remoteOut))
-	if len(submatches) == 1 {
-		return errors.New("could not parse ls-remote --symref origin HEAD output")
+	if len(submatches) < 2 {
+		return errors.New(fmt.Sprintf("%s: could not parse `ls-remote --symref origin HEAD` output: %s\n", r.Name, string(remoteOut)))
 	}
 	remoteHead := strings.TrimSpace(submatches[1])
 


### PR DESCRIPTION
This should fix the issue @juliannadeau-stripe was seeing in their deployment with empty repos causing a crash. I've been running this patch on our deployment which has plenty of empty git repos and no failures so far. 

These are two commits I missed in prepping #340 for upstream, as mentioned in #341.

Proof of fix. Before:
```
$ main
$ ./bazel-bin/cmd/livegrep-fetch-reindex/livegrep-fetch-reindex_/livegrep-fetch-reindex -num-workers=60 -out=xvandish.idx ../repos-for-livegrep/xvandish.json
Updating xvandish/aws-go-photo-resize-lambda
Updating xvandish/dotfiles
Updating xvandish/livegrep
Updating xvandish/aws-node-photo-resize-lambda
Updating xvandish/livegrep-fragment
Updating xvandish/livegrep.com
Updating xvandish/my-empty-repo
Updating xvandish/aws-node-photo-delete-lambda
panic: runtime error: index out of range [1] with length 0

goroutine 28 [running]:
main.checkoutOne(0x1400027a400)
	cmd/livegrep-fetch-reindex/main.go:337 +0xfd8
main.checkoutWorker(0x1400010e2a0, 0x1400010e300, 0x1400013a8a0)
	cmd/livegrep-fetch-reindex/main.go:154 +0x8c
main.checkoutRepos.func1(0x140001234c0, 0x1400010e2a0, 0x1400010e300, 0x1400013a8a0)
	cmd/livegrep-fetch-reindex/main.go:121 +0x60
created by main.checkoutRepos
	cmd/livegrep-fetch-reindex/main.go:119 +0xf8
```

After: (successful run)
```
$ update-head-ref-patches
$ ./bazel-bin/cmd/livegrep-fetch-reindex/livegrep-fetch-reindex_/livegrep-fetch-reindex -num-workers=60 -out=xvandish.idx ../repos-for-livegrep/xvandish.json
Updating xvandish/aws-go-photo-resize-lambda
Updating xvandish/aws-node-photo-delete-lambda
Updating xvandish/aws-node-photo-resize-lambda
Updating xvandish/livegrep.com
Updating xvandish/my-empty-repo
.....
== end metrics ==
```

@juliannadeau-stripe let me know if anything goes awry during validation and I'll fix it up! 