### PR TITLE
Make /search API requests with POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ can see a running instance at
 Building
 --------
 
-livegrep builds using [bazel][bazel]. You will need to
-[install][bazel-install] a fairly recent version: as of this writing
-we test on bazel 4.0.0.
+livegrep builds using [bazel][bazel]. You will need to 
+[install][bazel-install] with a version matching that in `.bazelversion`.
+Running bazel via [bazelisk][bazelisk] will download the right version
+automatically.
 
 livegrep vendors and/or fetches all of its dependencies using `bazel`,
 and so should only require a relatively recent C++ compiler to build.
@@ -25,6 +26,7 @@ dependencies. These will be cached once downloaded.
 
 [bazel]: http://www.bazel.io/
 [bazel-install]: http://www.bazel.io/docs/install.html
+[bazelisk]: https://bazel.build/install/bazelisk
 
 Invoking
 --------

--- a/server/api.go
+++ b/server/api.go
@@ -48,8 +48,13 @@ func writeQueryError(ctx context.Context, w http.ResponseWriter, err error) {
 }
 
 func extractQuery(ctx context.Context, r *http.Request) (pb.Query, bool, error) {
-	params := r.URL.Query()
 	var query pb.Query
+
+	if err := r.ParseForm(); err != nil {
+		return query, false, err
+	}
+
+	params := r.Form
 	var err error
 
 	regex := true

--- a/server/server.go
+++ b/server/server.go
@@ -348,8 +348,12 @@ func New(cfg *config.Config) (http.Handler, error) {
 	m.Add("GET", "/opensearch.xml", srv.Handler(srv.ServeOpensearch))
 	m.Add("GET", "/", srv.Handler(srv.ServeRoot))
 
+	// GET (with query parameters) is for backward compatibility; the UI now
+	// uses POST (with form parameters).
 	m.Add("GET", "/api/v1/search/:backend", srv.Handler(srv.ServeAPISearch))
 	m.Add("GET", "/api/v1/search/", srv.Handler(srv.ServeAPISearch))
+	m.Add("POST", "/api/v1/search/:backend", srv.Handler(srv.ServeAPISearch))
+	m.Add("POST", "/api/v1/search/", srv.Handler(srv.ServeAPISearch))
 
 	var h http.Handler = m
 

--- a/web/src/codesearch/codesearch.js
+++ b/web/src/codesearch/codesearch.js
@@ -38,9 +38,12 @@ var Codesearch = function() {
         repo: opts.repo
       };
 
-      url = url + "?" + $.param(q);
-
-      var xhr = $.getJSON(url);
+      var xhr = $.ajax({
+        method: 'POST',
+        url: url,
+        data: q,
+        dataType: "json",
+      });
       var start = new Date();
       xhr.done(function (data) {
         var elapsed = new Date() - start;


### PR DESCRIPTION
With GET, the `repos` parameter may grow the URL beyond the maximum
length permitted by the server.

Use POST instead.

Fixes #259.

Also, improve the bazel installation instructions in the README.