### PR TITLE
Fix up Bazel config for http_proxy forwarding and supporting darwin_arm64

### DIFF
--- a/tools/org_dropbox_rules_node/node/defs.bzl
+++ b/tools/org_dropbox_rules_node/node/defs.bzl
@@ -22,7 +22,7 @@ runfiles_tmpl = '''#!/bin/bash -eu
 #       to prevent Python from prepending '' to sys.path and allowing
 #       modules from $PWD to be imported as top level modules.
 
-STUBPATH=$(/usr/bin/env python -ESs <(echo "import os.path; print(os.path.realpath(os.path.abspath('$0').split('.runfiles')[0]));"))
+STUBPATH=$(/usr/bin/env python3 -ESs <(echo "import os.path; print(os.path.realpath(os.path.abspath('$0').split('.runfiles')[0]));"))
 STUBPATH=$STUBPATH.runfiles
 
 export RUNFILES=$STUBPATH/{workspace_name}

--- a/tools/org_dropbox_rules_node/node/defs.bzl
+++ b/tools/org_dropbox_rules_node/node/defs.bzl
@@ -144,12 +144,6 @@ def _npm_library_impl(ctx):
     if ctx.attr.npm_installer_extra_args:
         command_args.extend(ctx.attr.npm_installer_extra_args)
 
-    env = {}
-    if "HTTP_PROXY" in ctx.var:
-        env["HTTP_PROXY"] = ctx.var["HTTP_PROXY"]
-    if "HTTPS_PROXY" in ctx.var:
-        env["HTTPS_PROXY"] = ctx.var["HTTPS_PROXY"]
-
     ctx.actions.run(
         inputs = [shrinkwrap],
         outputs = node_modules_srcs_dict.values(),
@@ -157,7 +151,7 @@ def _npm_library_impl(ctx):
         arguments = command_args,
         progress_message = "installing node modules from {}".format(shrinkwrap.path),
         mnemonic = "InstallNPMModules",
-        env = env,
+        use_default_shell_env = True,
     )
 
     all_node_modules = _new_all_node_modules()

--- a/tools/org_dropbox_rules_node/node/tools/npm/utils.py
+++ b/tools/org_dropbox_rules_node/node/tools/npm/utils.py
@@ -83,10 +83,9 @@ def run_npm(cmd, env=None, cwd=None):
     if env:
         full_env.update(env)
 
-    if 'HTTP_PROXY' in os.environ:
-        full_env['HTTP_PROXY'] = os.environ['HTTP_PROXY']
-    if 'HTTPS_PROXY' in os.environ:
-        full_env['HTTPS_PROXY'] = os.environ['HTTPS_PROXY']
+    for env_var in ('HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy'):
+        if env_var in os.environ:
+            full_env[env_var] = os.environ[env_var]
 
     try:
         ret = subprocess.check_output(

--- a/web/BUILD
+++ b/web/BUILD
@@ -37,7 +37,7 @@ genrule(
         "//web:webpack_build",
     ],
     outs = ["hashes.txt"],
-    cmd = "sha256sum $(SRCS) | sed \"s_ $(BINDIR)/_ _\" | sed \"s_ web/htdocs/_ _\"> $@",
+    cmd = """sha256sum $(SRCS) | sed "s# $(BINDIR)/# #" | sed "s# web/htdocs/# #"> $@""",
 )
 
 pkg_tar(


### PR DESCRIPTION
I'm hoping `/usr/bin/env python3` is a safe assumption to make in 2022: modern macOS doesn't have `python` present.

On arm64 Macs, the host component of the bindir is `darwin_arm64`. This breaks the `sed` command in the `genrule` creating `hashes.txt`, which used `_` as the delimiter. We can switch it to whatever won't be in that path.

Also, throwing this in the same PR, but open to separating it out:
We do a bizarre workaround to set `HTTP_PROXY` with `--define` flags -- instead, we should let Bazel forward the value from the environment with `--host_action_env` if it's needed. Consequently, we _shouldn't_ pass `env` when `use_default_shell_env = True` because those values are entirely ignored: https://github.com/bazelbuild/bazel/issues/5980.