### PR TITLE
Fix example url_pattern

### DIFF
--- a/doc/examples/livegrep/index.json
+++ b/doc/examples/livegrep/index.json
@@ -16,7 +16,7 @@
             "revisions": [ "HEAD" ],
             "metadata": {
                 "github": "livegrep/livegrep",
-                "url_pattern": "https://github.com/{name}/blob/{version}/src/{path}#L{lno}"
+                "url_pattern": "https://github.com/livegrep/livegrep/blob/{version}/src/{path}#L{lno}"
             }
         }
     ]


### PR DESCRIPTION
When not using the file viewer, metadata.github takes precedence over
metadata.url_pattern.  When using the file viewer, only url_pattern is
consulted.  url_pattern is incorrect for this repository.  Fix it.