### PR TITLE
Fix/highlight all matches for upstream

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -172,7 +172,6 @@ func (s *server) doSearch(ctx context.Context, backend *Backend, q *pb.Query) (*
 			ContextAfter:  stringSlice(r.ContextAfter),
 			Bounds:        convertBounds(r.NewBounds),
 			Line:          r.Line,
-			NumMatches:    int(r.NumMatches),
 		})
 	}
 
@@ -193,6 +192,7 @@ func (s *server) doSearch(ctx context.Context, backend *Backend, q *pb.Query) (*
 		AnalyzeTime: search.Stats.AnalyzeTime,
 		TotalTime:   int64(time.Since(start) / time.Millisecond),
 		ExitReason:  search.Stats.ExitReason.String(),
+		NumMatches:  int(search.Stats.NumMatches),
 	}
 	return reply, nil
 }

--- a/server/api.go
+++ b/server/api.go
@@ -172,6 +172,7 @@ func (s *server) doSearch(ctx context.Context, backend *Backend, q *pb.Query) (*
 			ContextAfter:  stringSlice(r.ContextAfter),
 			Bounds:        convertBounds(r.NewBounds),
 			Line:          r.Line,
+			NumMatches:    int(r.NumMatches),
 		})
 	}
 

--- a/server/api.go
+++ b/server/api.go
@@ -121,6 +121,15 @@ func stringSlice(ss []string) []string {
 	return []string{}
 }
 
+func convertBounds(bounds []*pb.Bounds) [][2]int {
+	convertedBounds := make([][2]int, 0, len(bounds))
+	for _, bound := range bounds {
+		convertedBounds = append(convertedBounds, [2]int{int(bound.Left), int(bound.Right)})
+	}
+
+	return convertedBounds
+}
+
 func (s *server) doSearch(ctx context.Context, backend *Backend, q *pb.Query) (*api.ReplySearch, error) {
 	var search *pb.CodeSearchResult
 	var err error
@@ -161,7 +170,7 @@ func (s *server) doSearch(ctx context.Context, backend *Backend, q *pb.Query) (*
 			LineNumber:    int(r.LineNumber),
 			ContextBefore: stringSlice(r.ContextBefore),
 			ContextAfter:  stringSlice(r.ContextAfter),
-			Bounds:        [2]int{int(r.Bounds.Left), int(r.Bounds.Right)},
+			Bounds:        convertBounds(r.NewBounds),
 			Line:          r.Line,
 		})
 	}

--- a/server/api.go
+++ b/server/api.go
@@ -170,7 +170,7 @@ func (s *server) doSearch(ctx context.Context, backend *Backend, q *pb.Query) (*
 			LineNumber:    int(r.LineNumber),
 			ContextBefore: stringSlice(r.ContextBefore),
 			ContextAfter:  stringSlice(r.ContextAfter),
-			Bounds:        convertBounds(r.NewBounds),
+			Bounds:        convertBounds(r.Bounds),
 			Line:          r.Line,
 		})
 	}

--- a/server/api/types.go
+++ b/server/api/types.go
@@ -26,6 +26,7 @@ type Stats struct {
 	AnalyzeTime int64  `json:"analyze_time"`
 	TotalTime   int64  `json:"total_time"`
 	ExitReason  string `json:"why"`
+	NumMatches  int    `json:"num_matches"`
 }
 
 type Result struct {
@@ -37,7 +38,6 @@ type Result struct {
 	ContextAfter  []string `json:"context_after"`
 	Bounds        [][2]int `json:"bounds"`
 	Line          string   `json:"line"`
-	NumMatches    int      `json:"num_matches"`
 }
 
 type FileResult struct {

--- a/server/api/types.go
+++ b/server/api/types.go
@@ -35,7 +35,7 @@ type Result struct {
 	LineNumber    int      `json:"lno"`
 	ContextBefore []string `json:"context_before"`
 	ContextAfter  []string `json:"context_after"`
-	Bounds        [2]int   `json:"bounds"`
+	Bounds        [][2]int `json:"bounds"`
 	Line          string   `json:"line"`
 }
 

--- a/server/api/types.go
+++ b/server/api/types.go
@@ -37,6 +37,7 @@ type Result struct {
 	ContextAfter  []string `json:"context_after"`
 	Bounds        [][2]int `json:"bounds"`
 	Line          string   `json:"line"`
+	NumMatches    int      `json:"num_matches"`
 }
 
 type FileResult struct {

--- a/src/codesearch.cc
+++ b/src/codesearch.cc
@@ -1013,12 +1013,11 @@ int searcher::find_matches_in_line(const StringPiece& line, int startPos, vector
     }
 
     StringPiece match;
-    int i = startPos;
     int line_len = line.length(); 
     int num_matches = bounds.size(); // this should only ever be 0 or 1
 
     run_timer run(re2_time_);
-    while (!limiter_.exit_early() && i < line_len && query_->line_pat->Match(line, i, line_len, RE2::UNANCHORED, &match, 1)) {
+    while (!limiter_.exit_early() && startPos < line_len && query_->line_pat->Match(line, startPos, line_len, RE2::UNANCHORED, &match, 1)) {
         num_matches += 1;
 
         int matchleft = match.data() - line.data();
@@ -1028,7 +1027,7 @@ int searcher::find_matches_in_line(const StringPiece& line, int startPos, vector
         // update the previous bounds - e.g., "merge" the intervals
         if (bounds.size() > 0 && bounds.back().matchright == matchleft) {
             bounds.back().matchright = matchright; 
-            i = matchright;
+            startPos = matchright;
             continue;
         }
 
@@ -1036,7 +1035,7 @@ int searcher::find_matches_in_line(const StringPiece& line, int startPos, vector
         mb.matchleft = matchleft;
         mb.matchright = matchright;
         bounds.push_back(mb);
-        i = mb.matchright;
+        startPos = mb.matchright;
     }
 
     re2_match_cache_[line] = pair<int, vector<match_bound>>(num_matches, bounds);

--- a/src/codesearch.cc
+++ b/src/codesearch.cc
@@ -142,6 +142,15 @@ public:
         }
     }
 
+    void record_n_matches(int n) {
+        int matches = matches_ += n;
+        if (exit_reason_)
+            return;
+        if (max_matches_ && matches >= max_matches_) {
+            exit_reason_ = kExitMatchLimit;
+        }
+    }
+
 protected:
     atomic_int matches_;
     int max_matches_;
@@ -291,6 +300,13 @@ p     * which contain `match', which is contained within `line'.
     void try_match(const StringPiece&,
                    const StringPiece&,
                    indexed_file *);
+
+    /*
+     * Given a line, find all matches and return their bounds. Starts 
+     * at startPos, in the case that we already know of some number of
+     * existing matches. Uses a cache based on `line`.
+     */
+    vector<match_bound> find_matches_in_line(const StringPiece& line, int startPos);
 
     static int line_start(const chunk *chunk, int pos) {
         const unsigned char *start = static_cast<const unsigned char*>
@@ -988,6 +1004,22 @@ void searcher::find_match(const chunk *chunk,
     }
 }
 
+vector<match_bound> find_matches_in_line(const StringPiece& line, int startPos) {
+    StringPiece match;
+    vector<match_bound> bounds;
+    int i = start;
+    int line_len = line.length(); 
+
+    while (i < line_len && query_->line_pat->Match(line, i, line_len, RE2::UNANCHORED, &match, 1)) {
+        match_bound mb;
+        mb.matchleft = utf8::distance(line.data(), match.data());
+        mb.matchright = mb.matchleft + utf8::distance(match.data(), match.data() + match.size());
+        bounds.push_back(mb);
+        i = mb.matchright + 1;
+    }
+
+    return bounds;
+}
 
 void searcher::try_match(const StringPiece& line,
                          const StringPiece& match,
@@ -1020,10 +1052,22 @@ void searcher::try_match(const StringPiece& line,
         m->matchright = m->matchleft +
             utf8::distance(match.data(), match.data() + match.size());
 
+        // turn the existing match into the new type
+        match_bound first_bound;
+        first_bound.matchleft = m->matchleft;
+        first_bound.matchright = m->matchright;
+
+        // find all matches in the initial line
+        vector<match_bound> mbs = find_matches_in_line(line, m->matchright + 1);
+        mbs.insert(mbs.begin(), first_bound); // inefficient but ok for now
+        m->match_bounds_v2 = mbs;
+
+
         // iterators for forward and backward context
         auto fit = it, bit = it;
         StringPiece l = line;
         int i = 0;
+        int matches_found = mbs.size();
 
         for (i = 0; i < query_->context_lines; i++) {
             if (l.data() == bit->data()) {
@@ -1033,7 +1077,14 @@ void searcher::try_match(const StringPiece& line,
                 l = StringPiece(bit->data() + bit->size() + 1, 0);
             }
             l = find_line(*bit, StringPiece(l.data() - 1, 0));
+            vector<match_bound> mbs = find_matches_in_line(l, 0);
+
             m->context_before.push_back(l);
+            context_line cl;
+            cl.line = l;
+            cl.match_bounds = mbs;
+            m->context_before_v2.push_back(cl);
+            matches_found += mbs.size();
         }
 
         l = line;
@@ -1045,12 +1096,20 @@ void searcher::try_match(const StringPiece& line,
                 l = StringPiece(fit->data() - 1, 0);
             }
             l = find_line(*fit, StringPiece(l.data() + l.size() + 1, 0));
+            vector<match_bound> mbs = find_matches_in_line(l, 0);
+
             m->context_after.push_back(l);
+
+            context_line cl;
+            cl.line = l;
+            cl.match_bounds = mbs;
+            m->context_after_v2.push_back(cl);
+            matches_found += mbs.size();
         }
 
         if (!transform_ || transform_(m)) {
             queue_.push(m);
-            limiter_.record_match();
+            limiter_.record_n_matches(matches_found);
         }
         if (limiter_.exit_early())
             break;

--- a/src/codesearch.cc
+++ b/src/codesearch.cc
@@ -355,7 +355,7 @@ p     * which contain `match', which is contained within `line'.
     timer sort_time_;
     timer analyze_time_;
     vector<uint8_t> files_;
-    map<StringPiece, vector<match_bound>> re2_match_cache_;
+    map<StringPiece, pair<int, vector<match_bound>>> re2_match_cache_;
 
     /*
      * The approximate ratio of how many files match file_pat and
@@ -1008,10 +1008,8 @@ void searcher::find_match(const chunk *chunk,
 int searcher::find_matches_in_line(const StringPiece& line, int startPos, vector<match_bound>& bounds) {
     auto cached_bounds = re2_match_cache_.find(line);
     if (cached_bounds != re2_match_cache_.end()) {
-        bounds = cached_bounds->second;
-        // TODO: return the actual length, since
-        // we merge the bounds
-        return bounds.size();
+        bounds = cached_bounds->second.second;
+        return cached_bounds->second.first;
     }
 
     StringPiece match;
@@ -1041,7 +1039,7 @@ int searcher::find_matches_in_line(const StringPiece& line, int startPos, vector
         i = mb.matchright;
     }
 
-    re2_match_cache_[line] = bounds;
+    re2_match_cache_[line] = pair<int, vector<match_bound>>(num_matches, bounds);
     return num_matches;
 }
 

--- a/src/codesearch.cc
+++ b/src/codesearch.cc
@@ -1069,17 +1069,15 @@ void searcher::try_match(const StringPiece& line,
         m->file = sf;
         m->lno  = lno;
         m->line = line;
-        m->matchleft = utf8::distance(line.data(), match.data());
-        m->matchright = m->matchleft +
-            utf8::distance(match.data(), match.data() + match.size());
 
         vector<match_bound> mbs;
         match_bound first_bound;
-        first_bound.matchleft = m->matchleft;
-        first_bound.matchright = m->matchright;
+        first_bound.matchleft = utf8::distance(line.data(), match.data());
+        first_bound.matchright = first_bound.matchleft + 
+            utf8::distance(match.data(), match.data() + match.size());
         mbs.push_back(first_bound);
 
-        int matches_found = find_matches_in_line(line, m->matchright, mbs);
+        int matches_found = find_matches_in_line(line, first_bound.matchright, mbs);
         m->match_bounds = mbs;
         m->num_matches = matches_found;
 

--- a/src/codesearch.cc
+++ b/src/codesearch.cc
@@ -1190,7 +1190,7 @@ void code_searcher::search_thread::match(const query &q,
 
     if (!q.filename_only) {
         while (search.queue_.pop(&m)) {
-            matches++;
+            matches += m->num_matches;
             cb(m);
             delete m;
         }

--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -92,13 +92,23 @@ struct index_info {
     vector<indexed_tree> trees;
 };
 
+struct match_bound {
+    int matchleft;
+    int matchright;
+};
+
+// empty bounds mean no match for q.line_pat on this line
+struct result_line {
+    StringPiece line;
+    vector<match_bound> match_bounds;
+};
+
 struct match_result {
     indexed_file *file;
     int lno;
-    vector<StringPiece> context_before;
-    vector<StringPiece> context_after;
-    StringPiece line;
-    int matchleft, matchright;
+    result_line line;
+    vector<result_line> context_before;
+    vector<result_line> context_after;
 };
 
 struct file_result {

--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -100,11 +100,9 @@ struct match_bound {
 struct match_result {
     indexed_file *file;
     int lno;
-    vector<StringPiece> context_before; 
+    vector<StringPiece> context_before;
     vector<StringPiece> context_after;
     StringPiece line;
-    int matchleft, matchright;
-
     vector<match_bound> match_bounds;
     int num_matches;
 };

--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -97,18 +97,16 @@ struct match_bound {
     int matchright;
 };
 
-// empty bounds mean no match for q.line_pat on this line
-struct result_line {
-    StringPiece line;
-    vector<match_bound> match_bounds;
-};
-
 struct match_result {
     indexed_file *file;
     int lno;
-    result_line line;
-    vector<result_line> context_before;
-    vector<result_line> context_after;
+    vector<StringPiece> context_before; 
+    vector<StringPiece> context_after;
+    StringPiece line;
+    int matchleft, matchright;
+
+    vector<match_bound> match_bounds;
+    int num_matches;
 };
 
 struct file_result {

--- a/src/proto/livegrep.proto
+++ b/src/proto/livegrep.proto
@@ -28,10 +28,8 @@ message SearchResult {
     int64 line_number = 4;
     repeated string context_before = 5;
     repeated string context_after = 6;
-    Bounds bounds = 7;
+    repeated Bounds bounds = 7;
     string line = 8;
-
-    repeated Bounds new_bounds = 9;
 }
 
 message FileResult {

--- a/src/proto/livegrep.proto
+++ b/src/proto/livegrep.proto
@@ -30,6 +30,9 @@ message SearchResult {
     repeated string context_after = 6;
     Bounds bounds = 7;
     string line = 8;
+
+    repeated Bounds new_bounds = 9;
+    int64 num_matches = 10;
 }
 
 message FileResult {

--- a/src/proto/livegrep.proto
+++ b/src/proto/livegrep.proto
@@ -32,7 +32,6 @@ message SearchResult {
     string line = 8;
 
     repeated Bounds new_bounds = 9;
-    int64 num_matches = 10;
 }
 
 message FileResult {
@@ -49,6 +48,7 @@ message SearchStats {
     int64 index_time = 4;
     int64 analyze_time = 5;
     int64 total_time = 7;
+    int64 num_matches = 8;
     enum ExitReason {
         NONE = 0;
         TIMEOUT = 1;

--- a/src/tagsearch.cc
+++ b/src/tagsearch.cc
@@ -119,14 +119,16 @@ bool tag_searcher::transform(query *q, match_result *m) const {
     m->line = *line_it;
 
     StringPiece match;
+    match_bound first_bound;
     if (q->line_pat->Match(m->line, 0, m->line.size(),
                            RE2::UNANCHORED, &match, 1)) {
-        m->matchleft = utf8::distance(m->line.data(), match.data());
-        m->matchright = m->matchleft + utf8::distance(match.data(), match.data() + match.size());
+        first_bound.matchleft = utf8::distance(m->line.data(), match.data());
+        first_bound.matchright = first_bound.matchleft + utf8::distance(match.data(), match.data() + match.size());
     } else {
-        m->matchleft = line_it->find(name);
-        m->matchright = m->matchleft + name.size();
+        first_bound.matchleft = line_it->find(name);
+        first_bound.matchright = first_bound.matchleft + name.size();
     }
+    m->match_bounds = vector<match_bound>{first_bound};
     ++line_it;
 
     // context after

--- a/src/tools/grpc_server.cc
+++ b/src/tools/grpc_server.cc
@@ -196,7 +196,6 @@ public:
             insert->set_right(mb.matchright);
         }
 
-        result->set_num_matches(m->num_matches);
         result->mutable_bounds()->set_left(m->matchleft);
         result->mutable_bounds()->set_right(m->matchright);
         result->set_line(m->line.ToString());
@@ -378,6 +377,7 @@ Status CodeSearchImpl::Search(ServerContext* context, const ::Query* request, ::
     out_stats->set_index_time(timeval_ms(stats.index_time));
     out_stats->set_analyze_time(timeval_ms(stats.analyze_time));
     out_stats->set_total_time(timeval_ms(search_tm.elapsed()));
+    out_stats->set_num_matches(stats.matches);
     switch (stats.why) {
     case kExitNone:
         out_stats->set_exit_reason(SearchStats::NONE);

--- a/src/tools/grpc_server.cc
+++ b/src/tools/grpc_server.cc
@@ -191,13 +191,11 @@ public:
         }
 
         for (auto &mb : m->match_bounds) {
-            auto insert = result->add_new_bounds();
+            auto insert = result->add_bounds();
             insert->set_left(mb.matchleft);
             insert->set_right(mb.matchright);
         }
 
-        result->mutable_bounds()->set_left(m->matchleft);
-        result->mutable_bounds()->set_right(m->matchright);
         result->set_line(m->line.ToString());
     }
 

--- a/src/tools/grpc_server.cc
+++ b/src/tools/grpc_server.cc
@@ -189,6 +189,14 @@ public:
         for (auto &piece : m->context_after) {
             insert_string_back(result->mutable_context_after(), piece);
         }
+
+        for (auto &mb : m->match_bounds) {
+            auto insert = result->add_new_bounds();
+            insert->set_left(mb.matchleft);
+            insert->set_right(mb.matchright);
+        }
+
+        result->set_num_matches(m->num_matches);
         result->mutable_bounds()->set_left(m->matchleft);
         result->mutable_bounds()->set_right(m->matchright);
         result->set_line(m->line.ToString());

--- a/test/codesearch_test.cc
+++ b/test/codesearch_test.cc
@@ -482,7 +482,7 @@ TEST_F(codesearch_test, ConsecutiveMatchBoundsMerged) {
     ASSERT_EQ(3, first_bound.right());
 }
 
-TEST_F(codesearch_test, WOperatorWithRepetition) {
+TEST_F(codesearch_test, WRegexOperator) {
     cs_.index_file(tree_, "/file1", "there should be five words");
     cs_.finalize();
 

--- a/test/codesearch_test.cc
+++ b/test/codesearch_test.cc
@@ -20,6 +20,34 @@ const char *file1 = "The quick brown fox\n" \
     "jumps over the lazy\n\n\n" \
     "dog.\n";
 
+std::vector<std::string> buildHighlightedStringFromBounds(CodeSearchResult matches) {
+    // we use the first result's bounds
+    std::vector<std::string> pieces;
+
+    int bounds_len = matches.results(0).new_bounds().size();
+    auto line = matches.results(0).line();
+
+    // this is a dup of the logic found in web/src/codesearch/codesearch_ui.js#L192
+    int currIdx = 0;
+    for (int i = 0; i < bounds_len; i++) {
+        auto bound = matches.results(0).new_bounds(i);  
+
+        if (bound.left() > currIdx) {
+            pieces.push_back(line.substr(currIdx, bound.left() - currIdx));
+        }
+
+        currIdx = bound.right();
+
+        pieces.push_back("<span>" + line.substr(bound.left(), bound.right() - bound.left()) + "</span>");
+
+        if (i == bounds_len - 1 && currIdx <= line.length()) {
+            pieces.push_back(line.substr(currIdx, line.length() - currIdx));
+        }
+    }
+
+    return pieces;
+}
+
 TEST_F(codesearch_test, IndexTest) {
     cs_.index_file(tree_, "/data/file1", file1);
     cs_.finalize();
@@ -400,4 +428,160 @@ TEST_F(codesearch_test, BadUTF8) {
     st = srv->Search(&ctx, &request, &matches);
     ASSERT_TRUE(st.ok());
     ASSERT_EQ(0, matches.results_size());
+}
+
+TEST_F(codesearch_test, AllMatchesOnLineFound) {
+    cs_.index_file(tree_, "/file1", "test --test-timeout=60s");
+    cs_.finalize();
+
+    std::unique_ptr<CodeSearch::Service> srv(build_grpc_server(&cs_, nullptr, nullptr));
+    Query request;
+    CodeSearchResult matches;
+    request.set_line("test");
+    
+    grpc::ServerContext ctx;
+
+    grpc::Status st = srv->Search(&ctx, &request, &matches);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ(1, matches.results_size());
+    ASSERT_EQ(2, matches.results(0).new_bounds().size());
+    ASSERT_EQ(2, matches.stats().num_matches());
+
+    // bounds should be [[0, 4], [7, 11]]
+    auto first_bound = matches.results(0).new_bounds(0);
+    auto second_bound = matches.results(0).new_bounds(1);
+
+    ASSERT_EQ(0, first_bound.left());
+    ASSERT_EQ(4, first_bound.right());
+
+    ASSERT_EQ(7, second_bound.left());
+    ASSERT_EQ(11, second_bound.right());
+}
+
+TEST_F(codesearch_test, ConsecutiveMatchBoundsMerged) {
+    cs_.index_file(tree_, "/file1", "ttt merge");
+    cs_.finalize();
+
+    std::unique_ptr<CodeSearch::Service> srv(build_grpc_server(&cs_, nullptr, nullptr));
+    Query request;
+    CodeSearchResult matches;
+    request.set_line("t");
+    
+    grpc::ServerContext ctx;
+
+    grpc::Status st = srv->Search(&ctx, &request, &matches);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ(1, matches.results_size());
+    ASSERT_EQ(1, matches.results(0).new_bounds().size());
+    ASSERT_EQ(3, matches.stats().num_matches());
+
+    auto first_bound = matches.results(0).new_bounds(0);
+    ASSERT_EQ(0, first_bound.left());
+    ASSERT_EQ(3, first_bound.right());
+}
+
+TEST_F(codesearch_test, WOperatorWithRepetition) {
+    cs_.index_file(tree_, "/file1", "there should be five words");
+    cs_.finalize();
+
+    std::unique_ptr<CodeSearch::Service> srv(build_grpc_server(&cs_, nullptr, nullptr));
+    Query request;
+    CodeSearchResult matches;
+    request.set_line("(\\w+)");
+    
+    grpc::ServerContext ctx;
+
+    grpc::Status st = srv->Search(&ctx, &request, &matches);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ(1, matches.results_size());
+    ASSERT_EQ(5, matches.results(0).new_bounds().size());
+    ASSERT_EQ(5, matches.stats().num_matches());
+
+
+    std::vector<std::vector<int>> v = {{0,5}, {6,12}, {13,15}, {16,20}, {21, 26}}; 
+
+    for (int i = 0; i < v.size(); i++) {
+        auto bound = matches.results(0).new_bounds(i);
+        ASSERT_EQ(v[i][0], bound.left());
+        ASSERT_EQ(v[i][1], bound.right());
+    }
+
+    // Now that we attempt to find all matches on a line, no matter the input,
+    // any regex operator will act as if it wrapped in a repetition operator
+    // so, for example, (\w) should act the same as (\w+) - at a high level
+    matches.Clear();
+    request.set_line("(\\w)");
+    st = srv->Search(&ctx, &request, &matches);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ(1, matches.results_size());
+    // bounds will be the same size as before, because we merge consecutive
+    ASSERT_EQ(5, matches.results(0).new_bounds().size());
+    // however, since we're matching an inidivudal \w at a time, we'll have way
+    // more matches than before (5)
+    ASSERT_EQ(22, matches.stats().num_matches());
+
+    for (int i = 0; i < v.size(); i++) {
+        auto bound = matches.results(0).new_bounds(i);
+        ASSERT_EQ(v[i][0], bound.left());
+        ASSERT_EQ(v[i][1], bound.right());
+    }
+}
+
+TEST_F(codesearch_test, UnicodeLines) {
+    cs_.index_file(tree_, "/file1", 
+            "/ \u21B4 / /\n"
+            "\u25BC\n"
+            "line 3");
+    cs_.finalize();
+
+    std::unique_ptr<CodeSearch::Service> srv(build_grpc_server(&cs_, nullptr, nullptr));
+    Query request;
+    CodeSearchResult matches;
+    request.set_line("/");
+    
+    grpc::ServerContext ctx;
+
+    grpc::Status st = srv->Search(&ctx, &request, &matches);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ(1, matches.results_size());
+    ASSERT_EQ(1, matches.results(0).line_number());
+    ASSERT_EQ(3, matches.results(0).new_bounds().size());
+    ASSERT_EQ(3, matches.stats().num_matches());
+
+
+    // but again, bounds are the same as before because of bounds merging
+    std::vector<std::vector<int>> v = {{0,1}, {6,7}, {8,9}}; 
+
+    for (int i = 0; i < v.size(); i++) {
+        auto bound = matches.results(0).new_bounds(i);
+        ASSERT_EQ(v[i][0], bound.left());
+        ASSERT_EQ(v[i][1], bound.right());
+    }
+
+    // now, we take our first line, and make sure we can reconstruct
+    // a "highlighted" version of it
+    std::vector<std::string> expected = {"<span>/</span>", " \u21B4 ", "<span>/</span>", " ", "<span>/</span>", ""};
+    std::vector<std::string> pieces = buildHighlightedStringFromBounds(matches);
+    ASSERT_EQ(expected, pieces);
+
+
+    // --------------------------
+    matches.Clear();
+    request.set_line("\u25BC");
+    st = srv->Search(&ctx, &request, &matches);
+    ASSERT_TRUE(st.ok());
+
+
+    ASSERT_EQ(1, matches.results_size());
+    ASSERT_EQ(2, matches.results(0).line_number());
+    ASSERT_EQ(1, matches.results(0).new_bounds().size());
+
+    ASSERT_EQ(0, matches.results(0).new_bounds(0).left());
+    ASSERT_EQ(1, matches.results(0).new_bounds(0).right());
+
 }

--- a/test/codesearch_test.cc
+++ b/test/codesearch_test.cc
@@ -24,13 +24,13 @@ std::vector<std::string> buildHighlightedStringFromBounds(CodeSearchResult match
     // we use the first result's bounds
     std::vector<std::string> pieces;
 
-    int bounds_len = matches.results(0).new_bounds().size();
+    int bounds_len = matches.results(0).bounds().size();
     auto line = matches.results(0).line();
 
     // this is a dup of the logic found in web/src/codesearch/codesearch_ui.js#L192
     int currIdx = 0;
     for (int i = 0; i < bounds_len; i++) {
-        auto bound = matches.results(0).new_bounds(i);  
+        auto bound = matches.results(0).bounds(i);  
 
         if (bound.left() > currIdx) {
             pieces.push_back(line.substr(currIdx, bound.left() - currIdx));
@@ -445,12 +445,12 @@ TEST_F(codesearch_test, AllMatchesOnLineFound) {
     ASSERT_TRUE(st.ok());
 
     ASSERT_EQ(1, matches.results_size());
-    ASSERT_EQ(2, matches.results(0).new_bounds().size());
+    ASSERT_EQ(2, matches.results(0).bounds().size());
     ASSERT_EQ(2, matches.stats().num_matches());
 
     // bounds should be [[0, 4], [7, 11]]
-    auto first_bound = matches.results(0).new_bounds(0);
-    auto second_bound = matches.results(0).new_bounds(1);
+    auto first_bound = matches.results(0).bounds(0);
+    auto second_bound = matches.results(0).bounds(1);
 
     ASSERT_EQ(0, first_bound.left());
     ASSERT_EQ(4, first_bound.right());
@@ -474,10 +474,10 @@ TEST_F(codesearch_test, ConsecutiveMatchBoundsMerged) {
     ASSERT_TRUE(st.ok());
 
     ASSERT_EQ(1, matches.results_size());
-    ASSERT_EQ(1, matches.results(0).new_bounds().size());
+    ASSERT_EQ(1, matches.results(0).bounds().size());
     ASSERT_EQ(3, matches.stats().num_matches());
 
-    auto first_bound = matches.results(0).new_bounds(0);
+    auto first_bound = matches.results(0).bounds(0);
     ASSERT_EQ(0, first_bound.left());
     ASSERT_EQ(3, first_bound.right());
 }
@@ -497,14 +497,14 @@ TEST_F(codesearch_test, WOperatorWithRepetition) {
     ASSERT_TRUE(st.ok());
 
     ASSERT_EQ(1, matches.results_size());
-    ASSERT_EQ(5, matches.results(0).new_bounds().size());
+    ASSERT_EQ(5, matches.results(0).bounds().size());
     ASSERT_EQ(5, matches.stats().num_matches());
 
 
     std::vector<std::vector<int>> v = {{0,5}, {6,12}, {13,15}, {16,20}, {21, 26}}; 
 
     for (int i = 0; i < v.size(); i++) {
-        auto bound = matches.results(0).new_bounds(i);
+        auto bound = matches.results(0).bounds(i);
         ASSERT_EQ(v[i][0], bound.left());
         ASSERT_EQ(v[i][1], bound.right());
     }
@@ -519,13 +519,13 @@ TEST_F(codesearch_test, WOperatorWithRepetition) {
 
     ASSERT_EQ(1, matches.results_size());
     // bounds will be the same size as before, because we merge consecutive
-    ASSERT_EQ(5, matches.results(0).new_bounds().size());
+    ASSERT_EQ(5, matches.results(0).bounds().size());
     // however, since we're matching an inidivudal \w at a time, we'll have way
     // more matches than before (5)
     ASSERT_EQ(22, matches.stats().num_matches());
 
     for (int i = 0; i < v.size(); i++) {
-        auto bound = matches.results(0).new_bounds(i);
+        auto bound = matches.results(0).bounds(i);
         ASSERT_EQ(v[i][0], bound.left());
         ASSERT_EQ(v[i][1], bound.right());
     }
@@ -550,7 +550,7 @@ TEST_F(codesearch_test, UnicodeLines) {
 
     ASSERT_EQ(1, matches.results_size());
     ASSERT_EQ(1, matches.results(0).line_number());
-    ASSERT_EQ(3, matches.results(0).new_bounds().size());
+    ASSERT_EQ(3, matches.results(0).bounds().size());
     ASSERT_EQ(3, matches.stats().num_matches());
 
 
@@ -558,7 +558,7 @@ TEST_F(codesearch_test, UnicodeLines) {
     std::vector<std::vector<int>> v = {{0,1}, {6,7}, {8,9}}; 
 
     for (int i = 0; i < v.size(); i++) {
-        auto bound = matches.results(0).new_bounds(i);
+        auto bound = matches.results(0).bounds(i);
         ASSERT_EQ(v[i][0], bound.left());
         ASSERT_EQ(v[i][1], bound.right());
     }
@@ -579,9 +579,9 @@ TEST_F(codesearch_test, UnicodeLines) {
 
     ASSERT_EQ(1, matches.results_size());
     ASSERT_EQ(2, matches.results(0).line_number());
-    ASSERT_EQ(1, matches.results(0).new_bounds().size());
+    ASSERT_EQ(1, matches.results(0).bounds().size());
 
-    ASSERT_EQ(0, matches.results(0).new_bounds(0).left());
-    ASSERT_EQ(1, matches.results(0).new_bounds(0).right());
+    ASSERT_EQ(0, matches.results(0).bounds(0).left());
+    ASSERT_EQ(1, matches.results(0).bounds(0).right());
 
 }

--- a/web/src/codesearch/codesearch.js
+++ b/web/src/codesearch/codesearch.js
@@ -53,7 +53,13 @@ var Codesearch = function() {
         data.file_results.forEach(function (r) {
           Codesearch.delegate.file_match(opts.id, r);
         });
-        Codesearch.delegate.search_done(opts.id, elapsed, data.search_type, data.info.why);
+        Codesearch.delegate.search_done(
+          opts.id,
+          elapsed,
+          data.search_type,
+          data.info.why,
+          data.info.num_matches
+        );
       });
       xhr.fail(function(data) {
         window._err = data;

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -339,8 +339,15 @@ var SearchResultSet = Backbone.Collection.extend({
   },
 
   num_matches: function() {
+    console.log(this);
     return this.reduce(function(memo, file_group) {
-      return memo + file_group.matches.length;
+      var numMatches = 0;
+      for (var i = 0; i < file_group.matches.length; i++) {
+        var match = file_group.matches[i];
+        numMatches += match.get('num_matches');
+        console.log('num_matches[' + i + ']=' + match.get('num_matches'));
+      }
+      return memo + numMatches;
     }, 0);
   }
 });

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -188,9 +188,27 @@ var MatchView = Backbone.View.extend({
     }
     var line = this.model.get('line');
     var bounds = this.model.get('bounds');
-    var pieces = [line.substring(0, bounds[0]),
-                  line.substring(bounds[0], bounds[1]),
-                  line.substring(bounds[1])];
+
+    var pieces = []; 
+    var currIdx = 0;
+    for (var i = 0; i < bounds.length; i++) {
+      var bound = bounds[i]; 
+
+      // push a prefix, if any
+      if (bound[0] > currIdx) {
+        pieces.push(line.substring(currIdx, bound[0]))
+      }
+
+      currIdx = bound[1];
+
+      // push the actual match
+      pieces.push(h.span({cls: 'matchstr'}, [ line.substring(bound[0], bound[1]) ])); 
+
+      // if we're out ouf bounds to process, but there is still line remaining
+      if (i == bounds.length - 1 && currIdx <= line.length) {
+        pieces.push(line.substring(currIdx, line.length)); 
+      }
+    }
 
     var classes = ['match'];
     if(clip_before !== undefined) classes.push('clip-before');
@@ -211,7 +229,7 @@ var MatchView = Backbone.View.extend({
         ctx_before,
         [
             this._renderLno(lno, true),
-            h.span({cls: 'matchline'}, [pieces[0], h.span({cls: 'matchstr'}, [pieces[1]]), pieces[2]]),
+            h.span({cls: 'matchline'}, pieces),
             h.span({cls: 'matchlinks'}, links)
         ],
         ctx_after


### PR DESCRIPTION
Hello, this PR attempts to highlight all matches of a search query on a line, instead of just the first match.

I've introduced a breaking change, just to get the migration over with, in `livegrep.proto`, that allows for a range of match bounds per matching line. This change is carried from the c++ server to the frontend.

```diff
diff --git a/src/proto/livegrep.proto b/src/proto/livegrep.proto
index b5f086a..5cccfa3 100644
--- a/src/proto/livegrep.proto
+++ b/src/proto/livegrep.proto
@@ -28,7 +28,7 @@ message SearchResult {
     int64 line_number = 4;
     repeated string context_before = 5;
     repeated string context_after = 6;
-    Bounds bounds = 7;
+    repeated Bounds bounds = 7;
     string line = 8;
 }
 ```

I think things may explode spectacularly on people who expect `Bounds` to be a single field, I've gone that direction though instead of a soft deprecation + new field. Happy to pivot there.

Heres a screenshot of the what a simple literal query looks like:
![Screen Shot 2022-08-21 at 2 25 25 PM](https://user-images.githubusercontent.com/23644345/185811553-3bdbf6d9-e5fd-4944-bd4b-74a4e7f411eb.png)

Oh, I tried to make sure that tagsearch remains working, but the ctags I have on my machine (Universal Ctags) caused the tagsearcher to report `unknown ctags format ...` on searcher so the new lines I added were never triggered, but theoretically they should work. And the brute force approach that triggered still highlighted matches just fine.

Closes #64.