### PR TITLE
Allow to click on query hint

### DIFF
--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -817,6 +817,18 @@ var CodesearchUI = function() {
       CodesearchUI.toggle_context();
 
       Codesearch.connect(CodesearchUI);
+      $('.query-hint code').click(function(e) {
+        var ext = e.target.textContent;
+        var q = CodesearchUI.input.val();
+        if( !q.includes(ext)
+            && ((ext.indexOf('-') == 0 && !q.includes(ext.substring(1)))
+            || (ext.indexOf('-') != 0 && !q.includes('-' + ext.substring)))
+        ) {
+          q = q + ' ' + ext;
+        }
+        CodesearchUI.input.val(q);
+        CodesearchUI.input.focus();
+       })
 
       // Update the search when the user hits Forward or Back.
       window.onpopstate = function(event) {


### PR DESCRIPTION
Hello, this PR allow to click on the query hint to add it to the search and then focus on the search input to complete the query hint.