### PR TITLE
Allow Go server config to specify grpc dial opts

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -139,6 +139,7 @@ load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
 
 npm_translate_lock(
     name = "npm",
+    npmrc = "//web:.npmrc",
     pnpm_lock = "//web:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",
 )

--- a/server/backend.go
+++ b/server/backend.go
@@ -31,8 +31,10 @@ type Backend struct {
 	Codesearch pb.CodeSearchClient
 }
 
-func NewBackend(id string, addr string) (*Backend, error) {
-	client, err := grpc.Dial(addr, grpc.WithInsecure())
+func NewBackend(id string, addr string, extraOpts ...grpc.DialOption) (*Backend, error) {
+	dialOpts := []grpc.DialOption{grpc.WithInsecure()}
+	dialOpts = append(dialOpts, extraOpts...)
+	client, err := grpc.Dial(addr, dialOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -63,6 +63,12 @@ type Config struct {
 	DefaultSearchRepos []string `json:"default_search_repos"`
 
 	LinkConfigs []LinkConfig `json:"file_links"`
+
+	// Maximum gRPC receive message size in bytes: this allows larger result sets from codesearch
+	GrpcMaxRecvMessageSize int `json:"grpc_max_recv_message_size"`
+
+	// Maximum gRPC send message size in bytes: this allows larger queries to codesearch
+	GrpcMaxSendMessageSize int `json:"grpc_max_send_message_size"`
 }
 
 type IndexConfig struct {


### PR DESCRIPTION
Fixes #360.

I deployed this change and with the corresponding flag to `codesearch` was actually able to see larger responses in the frontend. (Something like `max_matches:3000` is enough to hit the limit for the query I ran.)

The `WORKSPACE` change is just to silence a warning.