### PR TITLE
Allow setting 'target' attr on link configs

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -88,4 +88,5 @@ type LinkConfig struct {
 	Label            string `json:"label"`
 	UrlTemplate      string `json:"url_template"`
 	WhitelistPattern string `json:"whitelist_pattern"`
+	Target           string `json:"target"`
 }

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -120,17 +120,21 @@ function renderLinkConfigs(linkConfigs, tree, version, path, lno) {
 
   var links = linkConfigs.map(
     function(linkConfig) {
+      var attrs = {
+        cls: "file-action-link",
+        href: externalUrl(
+          linkConfig.url_template,
+          tree,
+          version,
+          path,
+          lno
+        ),
+      };
+      if (linkConfig.target) {
+        attrs.target = linkConfig.target;
+      }
       return h.a(
-        {
-          cls: "file-action-link",
-          href: externalUrl(
-            linkConfig.url_template,
-            tree,
-            version,
-            path,
-            lno
-          ),
-        },
+        attrs,
         [linkConfig.label]
       );
     }


### PR DESCRIPTION
We want to set `target="_blank"` on some file links.