### PR TITLE
Add config option for file extension, language mapping

### DIFF
--- a/doc/examples/livegrep/server.json
+++ b/doc/examples/livegrep/server.json
@@ -9,5 +9,8 @@
     "feedback": {
         "mailto": "nelhage@nelhage.com"
     },
-    "listen": "0.0.0.0:8910"
+    "listen": "0.0.0.0:8910",
+    "file_ext_to_lang": {
+        ".tf": "HCL"
+    }
 }

--- a/doc/examples/livegrep/server.json
+++ b/doc/examples/livegrep/server.json
@@ -12,5 +12,8 @@
     "listen": "0.0.0.0:8910",
     "file_ext_to_lang": {
         ".tf": "HCL"
+    },
+    "file_first_line_regex_to_lang": {
+        "^#!.*\bzsh\b": "bash"
     }
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -72,6 +72,11 @@ type Config struct {
 
 	// Additional file extensions to highlight with PrismJS in the built-in fileview
 	FileExtToLang map[string]string `json:"file_ext_to_lang"`
+
+	// Regular expression to match the first line of a file to determine its
+	// language.  This is used to override the language detection for files that
+	// don't have a recognized extension.
+	FileFirstLineRegexToLang map[string]string `json:"file_first_line_regex_to_lang"`
 }
 
 type IndexConfig struct {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -69,6 +69,9 @@ type Config struct {
 
 	// Maximum gRPC send message size in bytes: this allows larger queries to codesearch
 	GrpcMaxSendMessageSize int `json:"grpc_max_send_message_size"`
+
+	// Additional file extensions to highlight with PrismJS in the built-in fileview
+	FileExtToLang map[string]string `json:"file_ext_to_lang"`
 }
 
 type IndexConfig struct {

--- a/server/fileview.go
+++ b/server/fileview.go
@@ -71,6 +71,13 @@ var extToLangMap map[string]string = map[string]string{
 	".yaml":        "yaml",
 	".yml":         "yaml",
 }
+var fileFirstLineToLangMap map[*regexp.Regexp]string = map[*regexp.Regexp]string{
+	regexp.MustCompile(`^#!.*\bpython[23]?\b`): "python",
+	regexp.MustCompile(`^#!.*\bbash\b`):        "bash",
+	regexp.MustCompile(`^#!.*\bsh\b`):          "bash",
+	regexp.MustCompile(`^#!.*\bruby\b`):        "ruby",
+	regexp.MustCompile(`^#!.*\bperl\b`):        "perl",
+}
 
 // Grabbed from the extensions GitHub supports here - https://github.com/github/markup
 var supportedReadmeExtensions = []string{
@@ -241,6 +248,15 @@ func buildDirectoryListEntry(treeEntry gitTreeEntry, pathFromRoot string, repo c
 	}
 }
 
+func languageFromFirstLine(line string) string {
+	for regex, lang := range fileFirstLineToLangMap {
+		if regex.MatchString(line) {
+			return lang
+		}
+	}
+	return ""
+}
+
 func buildFileData(relativePath string, repo config.RepoConfig, commit string) (*fileViewerContext, error) {
 	commitHash := commit
 	out, err := gitCommitHash(commit, repo.Path)
@@ -309,6 +325,12 @@ func buildFileData(relativePath string, repo config.RepoConfig, commit string) (
 		language := filenameToLangMap[filepath.Base(cleanPath)]
 		if language == "" {
 			language = extToLangMap[filepath.Ext(cleanPath)]
+		}
+		if language == "" {
+			firstLine, _, found := strings.Cut(string(content), "\n")
+			if found {
+				language = languageFromFirstLine(firstLine)
+			}
 		}
 		fileContent = &sourceFileContent{
 			Content:   content,

--- a/server/server.go
+++ b/server/server.go
@@ -359,6 +359,10 @@ func New(cfg *config.Config) (http.Handler, error) {
 		repoNames = append(repoNames, r.Name)
 	}
 
+	for ext, lang := range srv.config.FileExtToLang {
+		extToLangMap[ext] = lang
+	}
+
 	serveFilePathRegex, err := buildRepoRegex(repoNames)
 	if err != nil {
 		return nil, err

--- a/server/server.go
+++ b/server/server.go
@@ -363,6 +363,14 @@ func New(cfg *config.Config) (http.Handler, error) {
 		extToLangMap[ext] = lang
 	}
 
+	for regexStr, lang := range srv.config.FileFirstLineRegexToLang {
+		regex, err := regexp.Compile(regexStr)
+		if err != nil {
+			return nil, err
+		}
+		fileFirstLineToLangMap[regex] = lang
+	}
+
 	serveFilePathRegex, err := buildRepoRegex(repoNames)
 	if err != nil {
 		return nil, err

--- a/web/templates/fileview.html
+++ b/web/templates/fileview.html
@@ -88,10 +88,10 @@
 </section>
 {{end}}
 
-<script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/prism.min.js" integrity="sha384-55dGHwJ+p8K+4zJGgJR7q7Fl9FuG++oKmlhKuS+dWjEMj6rBCp7AFYw55b0E5/K8" crossorigin="anonymous"></script>
-<script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/plugins/autoloader/prism-autoloader.min.js" integrity="sha384-S+UYfywCk42UjE2CVTgW2zT3c/X5Uw25LTU93Pn5HmyD5D31yHRu6I5VadHu3Qf5" crossorigin="anonymous"></script>
+<script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js" integrity="sha384-06z5D//U/xpvxZHuUz92xBvq3DqBBFi7Up53HRrbV7Jlv7Yvh/MZ7oenfUe9iCEt" crossorigin="anonymous"></script>
+<script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js" integrity="sha384-Uq05+JLko69eOiPr39ta9bh7kld5PKZoU+fF7g0EXTAriEollhZ+DrN8Q/Oi8J2Q" crossorigin="anonymous"></script>
 <script{{.Nonce}}>
   Prism.plugins.autoloader.languages_path =
-  'https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/components/';
+  'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/';
 </script>
 {{end}}


### PR DESCRIPTION
I've _long_ wanted a way to add new file extensions without a PR, merge, build dance -- finally got around to adding it.

The specific motivation was terraform `.tf` files, which a newer version of PrismJS includes (as generic HCL, Hashicorp configuration language). I updated the example, though maybe we do want that as a default inclusion too.

Edit: I threw another small commit here to use a regex on the first line too -- we often have small shell (and Ruby of course 🙂) scripts that have no extension, but nevertheless would be much nicer to have highlighted:

`bin/groups-graph`:
<img width="347" alt="image" src="https://github.com/livegrep/livegrep/assets/60013602/6c8633f0-cdb1-4d3f-8ce4-0f0ae97b542a">
