### PR TITLE
Include git in base dockerfile

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:20.04
-RUN apt-get update && apt-get -y dist-upgrade
+RUN apt-get update \
+    && apt-get -y dist-upgrade \
+    && apt-get install -y git \
+    && apt-get clean
 
 ARG livegrep_version
 COPY ./builds/${livegrep_version}.tgz /livegrep.tgz

--- a/server/server.go
+++ b/server/server.go
@@ -161,7 +161,7 @@ func (s *server) ServeFile(ctx context.Context, w http.ResponseWriter, r *http.R
 
 	data, err := buildFileData(path, repo, commit)
 	if err != nil {
-		http.Error(w, "Error reading file", 500)
+		http.Error(w, "Error reading file: "+err.Error(), 500)
 		return
 	}
 


### PR DESCRIPTION
The base image currently only spits out "Error reading file". Adding git to the image fixes the issue.