### PR TITLE
Fix CI: Disable the interactive dialogue in APT

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 RUN apt-get update \
     && apt-get -y dist-upgrade \
-    && apt-get install -y git \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y git \
     && apt-get clean
 
 ARG livegrep_version

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM livegrep/base
 RUN apt-get update && apt-get -y dist-upgrade
-RUN apt-get -y install nginx
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install nginx
 
 # the base image adds ./livegrep/nginx.conf for us, messy, but
 # works for now


### PR DESCRIPTION
I think #371 broke the CI because APT is waiting for input and the build times-out. 

[Reference](https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai)

I tested it on my fork and it seems to work, [see here.](https://github.com/mucinoab/livegrep/actions/runs/5481686560
)