### PR TITLE
Fix search update loss, when selecting repos using group header.

### DIFF
--- a/web/src/codesearch/repo_selector.js
+++ b/web/src/codesearch/repo_selector.js
@@ -18,7 +18,7 @@ function init() {
             var optgroup = $('#repos optgroup[label="' + $(this).text() + '"]')
             var allSelected = !optgroup.children('option:not(:selected)').length;
             optgroup.children().prop('selected', !allSelected);
-            $("#repos").selectpicker('refresh');
+            $("#repos").selectpicker('refresh').trigger("change");
         });
     });
     $(window).on('keyup', '.bootstrap-select .bs-searchbox input', function(event) {


### PR DESCRIPTION
In recently added repos grouping feature bug was detected. After selecting a number of repos using group header, search results weren't updating. Small fix for this problem here.