### PR TITLE
Add an "I'm feeling lucky" query param

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -47,14 +48,8 @@ func writeQueryError(ctx context.Context, w http.ResponseWriter, err error) {
 	}
 }
 
-func extractQuery(ctx context.Context, r *http.Request) (pb.Query, bool, error) {
+func extractQuery(ctx context.Context, r *http.Request, params url.Values) (pb.Query, bool, error) {
 	var query pb.Query
-
-	if err := r.ParseForm(); err != nil {
-		return query, false, err
-	}
-
-	params := r.Form
 	var err error
 
 	regex := true
@@ -203,7 +198,12 @@ func (s *server) ServeAPISearch(ctx context.Context, w http.ResponseWriter, r *h
 		}
 	}
 
-	q, is_regex, err := extractQuery(ctx, r)
+	err := r.ParseForm()
+	if err != nil {
+		writeError(ctx, w, 400, "bad_query", err.Error())
+		return
+	}
+	q, is_regex, err := extractQuery(ctx, r, r.Form)
 
 	if err != nil {
 		writeError(ctx, w, 400, "bad_query", err.Error())

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -63,6 +63,7 @@ function shorten(ref) {
   return ref;
 }
 
+// Keep these URL functions in sync with server.go.
 function url(tree, version, path, lno) {
   if (tree in CodesearchUI.internalViewRepos) {
     return internalUrl(tree, path, lno);


### PR DESCRIPTION
Someone mentioned to me they'd like to be able to jump directly the file viewer (or on GitHub etc.) when there's only a single result -- useful for linking from Slack or documentation for a unique constant, for example.

(That said this _is_ a little bit silly. It's also not discoverable because I didn't add it to the UI. (For use in a go link, it's fine.) It also ended up being a bit more code than I hoped, but :go-intensifies:. Feel free to merge, or not!)