### PR TITLE
Support queries with multiple path: terms

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,6 @@
 # c.f. https://github.com/grpc/grpc/pull/13929
 build --copt=-DGRPC_BAZEL_BUILD
+
+# abseil requires at least C++14, as of Jan 2023
+# https://github.com/abseil/abseil-cpp/releases/tag/20230125.3
+build --host_cxxopt=-std=c++14 --cxxopt=-std=c++14

--- a/.bazelrc.ci
+++ b/.bazelrc.ci
@@ -1,5 +1,9 @@
 startup --host_jvm_args=-Dbazel.DigestFunction=sha256
 
+# abseil requires at least C++14, as of Jan 2023
+# https://github.com/abseil/abseil-cpp/releases/tag/20230125.3
+build --host_cxxopt=-std=c++14 --cxxopt=-std=c++14
+
 # Ensure sandboxing is on to increase hermeticity.
 build --spawn_strategy=sandboxed
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+  "go.toolsEnvVars": {
+    "GOPACKAGESDRIVER": "${workspaceFolder}/tools/gopackagesdriver.sh"
+  },
+  "gopls": {
+    "build.directoryFilters": [
+      "-bazel-bin",
+      "-bazel-out",
+      "-bazel-testlogs",
+      "-bazel-livegrep"
+    ],
+    "formatting.gofumpt": false,
+    "formatting.local": "github.com/livegrep/livegrep",
+    "ui.completion.usePlaceholders": true,
+    "ui.semanticTokens": true,
+  },
+  "go.useLanguageServer": true,
+  "go.lintOnSave": "off",
+  "go.vetOnSave": "off"
+}

--- a/BUILD
+++ b/BUILD
@@ -1,11 +1,12 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@com_grail_bazel_compdb//:aspects.bzl", "compilation_database")
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
-compilation_database(
+refresh_compile_commands(
     name = "compilation_db",
     targets = [
         "//src/tools:codesearch",
         "//src/tools:codesearchtool",
+        "//test:codesearch_test",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -111,11 +111,17 @@ git_repository(
     remote = "https://github.com/bazelbuild/buildifier.git",
 )
 
-git_repository(
-    name = "com_grail_bazel_compdb",
-    commit = "7658de071fcd072163c24cc96d78e9891d4d81f5",
-    remote = "https://github.com/grailbio/bazel-compilation-database.git",
+http_archive(
+    name = "hedron_compile_commands",
+
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/e16062717d9b098c3c2ac95717d2b3e661c50608.tar.gz",
+    sha256 = "ed5aea1dc87856aa2029cb6940a51511557c5cac3dbbcb05a4abd989862c36b4",
+    strip_prefix = "bazel-compile-commands-extractor-e16062717d9b098c3c2ac95717d2b3e661c50608",
 )
+
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
+hedron_compile_commands_setup()
 
 git_repository(
     name = "com_google_googletest",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,6 +83,13 @@ http_archive(
     url = "https://github.com/libgit2/libgit2/archive/v0.27.9.tar.gz",
 )
 
+http_archive(
+    name = "com_google_absl",
+    sha256 = "497ebdc3a4885d9209b9bd416e8c3f71e7a1fb8af249f6c2a80b7cbeefcd7e21",
+    strip_prefix = "abseil-cpp-20230802.1/",
+    url = "https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip",
+)
+
 git_repository(
     name = "com_github_grpc_grpc",
     commit = "591d56e1300b6d11948e1b821efac785a295989c",  # 1.44.0

--- a/server/api.go
+++ b/server/api.go
@@ -75,9 +75,18 @@ func extractQuery(ctx context.Context, r *http.Request) (pb.Query, bool, error) 
 		}
 	}
 	if file, ok := params["file"]; ok {
-		query.File = file[0]
+		query.File = []string{file[0]}
 		if !regex {
-			query.File = regexp.QuoteMeta(query.File)
+			query.File = []string{regexp.QuoteMeta(file[0])}
+		}
+	}
+	if files, ok := params["file"]; ok {
+		query.File = files
+		if !regex {
+			query.File = make([]string, len(files))
+			for _, f := range files {
+				query.File = append(query.File, regexp.QuoteMeta(f))
+			}
 		}
 	}
 	if repo, ok := params["repo"]; ok {
@@ -88,7 +97,7 @@ func extractQuery(ctx context.Context, r *http.Request) (pb.Query, bool, error) 
 	}
 
 	// New-style repo multiselect, only if "repo:" is not in the query.
-	if query.Repo == "" {
+	if len(query.Repo) == 0 {
 		if newRepos, ok := params["repo[]"]; ok {
 			for i := range newRepos {
 				newRepos[i] = "^" + regexp.QuoteMeta(newRepos[i]) + "$"

--- a/server/query.go
+++ b/server/query.go
@@ -38,10 +38,20 @@ func onlyOneSynonym(ops map[string]string, op1 string, op2 string) (string, erro
 	return ops[op2], nil
 }
 
+func ensureSingleValue(ops map[string][]string, key string) (string, error) {
+	if len(ops[key]) > 1 {
+		return "", fmt.Errorf("multiple values for %s:", key)
+	}
+	if len(ops[key]) == 1 {
+		return ops[key][0], nil
+	}
+	return "", nil
+}
+
 func ParseQuery(query string, globalRegex bool) (pb.Query, error) {
 	var out pb.Query
 
-	ops := make(map[string]string)
+	ops := make(map[string][]string)
 	key := ""
 	term := ""
 	q := strings.TrimSpace(query)
@@ -52,10 +62,7 @@ func ParseQuery(query string, globalRegex bool) (pb.Query, error) {
 		m := pieceRE.FindStringSubmatchIndex(q)
 		if m == nil {
 			term += q
-			if _, alreadySet := ops[key]; alreadySet {
-				return out, fmt.Errorf("got term twice: %s", key)
-			}
-			ops[key] = term
+			ops[key] = append(ops[key], term)
 			break
 		}
 
@@ -71,10 +78,7 @@ func ParseQuery(query string, globalRegex bool) (pb.Query, error) {
 				term += " "
 
 			} else {
-				if _, alreadySet := ops[key]; alreadySet {
-					return out, fmt.Errorf("got term twice: %s", key)
-				}
-				ops[key] = term
+				ops[key] = append(ops[key], term)
 				key = ""
 				term = ""
 				inRegex = globalRegex
@@ -129,10 +133,7 @@ func ParseQuery(query string, globalRegex bool) (pb.Query, error) {
 			newKey := match[m[2]-m[0] : m[3]-m[0]]
 			if key == "" && knownTags[newKey] {
 				if strings.TrimSpace(term) != "" {
-					if _, alreadySet := ops[key]; alreadySet {
-						return out, fmt.Errorf("main search term must be contiguous")
-					}
-					ops[key] = term
+					ops[key] = append(ops[key], term)
 				}
 				term = ""
 				key = newKey
@@ -146,20 +147,39 @@ func ParseQuery(query string, globalRegex bool) (pb.Query, error) {
 		justGotSpace = (match == " ")
 	}
 
+	// This is a special case to provide a better error message,
+	// since the main search term is represented by the "" op.
+	if len(ops[""]) > 1 {
+		return out, fmt.Errorf("main search term must be contiguous")
+	}
+
+	// Handle synonyms
+	out.File = append(ops["file"], ops["path"]...)
+	out.NotFile = append(ops["-file"], ops["-path"]...)
+
 	var err error
-	if out.File, err = onlyOneSynonym(ops, "file", "path"); err != nil {
+	out.Repo, err = ensureSingleValue(ops, "repo")
+	if err != nil {
 		return out, err
 	}
-	out.Repo = ops["repo"]
-	out.Tags = ops["tags"]
-	if out.NotFile, err = onlyOneSynonym(ops, "-file", "-path"); err != nil {
+	out.Tags, err = ensureSingleValue(ops, "tags")
+	if err != nil {
 		return out, err
 	}
-	out.NotRepo = ops["-repo"]
-	out.NotTags = ops["-tags"]
+	out.NotRepo, err = ensureSingleValue(ops, "-repo")
+	if err != nil {
+		return out, err
+	}
+	out.NotTags, err = ensureSingleValue(ops, "-tags")
+	if err != nil {
+		return out, err
+	}
 	var bits []string
 	for _, k := range []string{"", "case", "lit"} {
-		bit := strings.TrimSpace(ops[k])
+		if _, ok := ops[k]; !ok {
+			continue
+		}
+		bit := strings.TrimSpace(ops[k][0])
 		if k == "lit" || !globalRegex {
 			bit = regexp.QuoteMeta(bit)
 		}
@@ -177,15 +197,22 @@ func ParseQuery(query string, globalRegex bool) (pb.Query, error) {
 	}
 
 	if !globalRegex {
-		out.File = regexp.QuoteMeta(out.File)
-		out.NotFile = regexp.QuoteMeta(out.NotFile)
+		for i, f := range out.File {
+			out.File[i] = regexp.QuoteMeta(f)
+		}
+		for i, f := range out.NotFile {
+			out.NotFile[i] = regexp.QuoteMeta(f)
+		}
 		out.Repo = regexp.QuoteMeta(out.Repo)
 		out.NotRepo = regexp.QuoteMeta(out.NotRepo)
 	}
 
-	if out.Line == "" && out.File != "" {
-		out.Line = out.File
-		out.File = ""
+	if len(out.Line) == 0 && len(out.File) != 0 {
+		// setting Line for a FilenameOnly search is a slight hack.
+		// it has compatibility with older backend code that expects a
+		// single filename regex, but a newer backend will use it to
+		// determine which match is highlighted.
+		out.Line = out.File[0]
 		out.FilenameOnly = true
 	}
 
@@ -196,7 +223,8 @@ func ParseQuery(query string, globalRegex bool) (pb.Query, error) {
 	} else {
 		out.FoldCase = strings.IndexAny(out.Line, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") == -1
 	}
-	if v, ok := ops["max_matches"]; ok && v != "" {
+	if v, ok := ops["max_matches"]; ok && v[0] != "" {
+		v := v[0]
 		i, err := strconv.Atoi(v)
 		if err == nil {
 			out.MaxMatches = int32(i)

--- a/server/query_test.go
+++ b/server/query_test.go
@@ -29,7 +29,7 @@ func TestParseQuery(t *testing.T) {
 			"line file:.rb",
 			pb.Query{
 				Line:     "line",
-				File:     ".rb",
+				File:     []string{".rb"},
 				FoldCase: true,
 			},
 			true,
@@ -56,12 +56,12 @@ func TestParseQuery(t *testing.T) {
 		},
 		{
 			"case:abc file:^kernel/",
-			pb.Query{Line: "abc", FoldCase: false, File: "^kernel/"},
+			pb.Query{Line: "abc", FoldCase: false, File: []string{"^kernel/"}},
 			true,
 		},
 		{
 			"case:abc file:( )",
-			pb.Query{Line: "abc", FoldCase: false, File: "( )"},
+			pb.Query{Line: "abc", FoldCase: false, File: []string{"( )"}},
 			true,
 		},
 		{
@@ -71,12 +71,12 @@ func TestParseQuery(t *testing.T) {
 		},
 		{
 			`a file:\(`,
-			pb.Query{Line: "a", File: `\(`, FoldCase: true},
+			pb.Query{Line: "a", File: []string{`\(`}, FoldCase: true},
 			true,
 		},
 		{
 			`a file:(\()`,
-			pb.Query{Line: "a", File: `(\()`, FoldCase: true},
+			pb.Query{Line: "a", File: []string{`(\()`}, FoldCase: true},
 			true,
 		},
 		{
@@ -96,12 +96,12 @@ func TestParseQuery(t *testing.T) {
 		},
 		{
 			`-file:Godep re`,
-			pb.Query{Line: "re", NotFile: "Godep", FoldCase: true},
+			pb.Query{Line: "re", NotFile: []string{"Godep"}, FoldCase: true},
 			true,
 		},
 		{
 			`-file:. -repo:Godep re`,
-			pb.Query{Line: "re", NotFile: ".", NotRepo: "Godep", FoldCase: true},
+			pb.Query{Line: "re", NotFile: []string{"."}, NotRepo: "Godep", FoldCase: true},
 			true,
 		},
 		{
@@ -136,44 +136,44 @@ func TestParseQuery(t *testing.T) {
 		},
 		{
 			`file:hello`,
-			pb.Query{Line: "hello", FoldCase: true, FilenameOnly: true},
+			pb.Query{Line: "hello", File: []string{"hello"}, FoldCase: true, FilenameOnly: true},
 			true,
 		},
 		{
 			`file:HELLO`,
-			pb.Query{Line: "HELLO", FoldCase: false, FilenameOnly: true},
+			pb.Query{Line: "HELLO", File: []string{"HELLO"}, FoldCase: false, FilenameOnly: true},
 			true,
 		},
 		{
 			`lit:a( file:b`,
-			pb.Query{Line: `a\(`, File: "b", FoldCase: false},
+			pb.Query{Line: `a\(`, File: []string{"b"}, FoldCase: false},
 			true,
 		},
 		{
 			`lit:a(b file:c`,
-			pb.Query{Line: `a\(b`, File: "c", FoldCase: false},
+			pb.Query{Line: `a\(b`, File: []string{"c"}, FoldCase: false},
 			true,
 		},
 		{
 			`[(] file:\.c`,
-			pb.Query{Line: `[(]`, File: "\\.c", FoldCase: true},
+			pb.Query{Line: `[(]`, File: []string{"\\.c"}, FoldCase: true},
 			true,
 		},
 		{
 			`[ ] file:\.c`,
-			pb.Query{Line: `[ ]`, File: "\\.c", FoldCase: true},
+			pb.Query{Line: `[ ]`, File: []string{"\\.c"}, FoldCase: true},
 			true,
 		},
 		{
 			`[ \]] file:\.c`,
-			pb.Query{Line: `[ \]]`, File: "\\.c", FoldCase: true},
+			pb.Query{Line: `[ \]]`, File: []string{"\\.c"}, FoldCase: true},
 			true,
 		},
 
 		// literal parse mode
 		{
 			"a( file:b",
-			pb.Query{Line: `a\(`, File: "b", FoldCase: true},
+			pb.Query{Line: `a\(`, File: []string{"b"}, FoldCase: true},
 			false,
 		},
 		{
@@ -208,8 +208,18 @@ func TestParseQuery(t *testing.T) {
 		},
 		{
 			"file:a( b",
-			pb.Query{Line: `b`, File: `a\(`, FoldCase: true},
+			pb.Query{Line: `b`, File: []string{`a\(`}, FoldCase: true},
 			false,
+		},
+		{
+			`file:a file:b path:c path:\.rb$ zoo`,
+			pb.Query{Line: "zoo", File: []string{"a", "b", "c", `\.rb$`}, FoldCase: true},
+			true,
+		},
+		{
+			`-file:a -path:b -file:c -path:\.rb$ zoo`,
+			pb.Query{Line: "zoo", NotFile: []string{"a", "c", "b", `\.rb$`}, FoldCase: true},
+			true,
 		},
 	}
 
@@ -237,6 +247,8 @@ func TestParseQueryError(t *testing.T) {
 		{"a max_matches:a"},
 		{"a file:b c"},
 		{"a file:((abc()())()) c"},
+		{"a repo:b repo:c"},
+		{"a -repo:b -repo:c"},
 	}
 
 	for _, tc := range cases {

--- a/src/codesearch.h
+++ b/src/codesearch.h
@@ -114,11 +114,11 @@ struct query {
     int32_t max_matches;
 
     std::shared_ptr<RE2> line_pat;
-    std::shared_ptr<RE2> file_pat;
+    vector<std::shared_ptr<RE2>> file_pats;
     std::shared_ptr<RE2> tree_pat;
     std::shared_ptr<RE2> tags_pat;
     struct {
-        std::shared_ptr<RE2> file_pat;
+        vector<std::shared_ptr<RE2>> file_pats;
         std::shared_ptr<RE2> tree_pat;
         std::shared_ptr<RE2> tags_pat;
     } negate;

--- a/src/proto/livegrep.proto
+++ b/src/proto/livegrep.proto
@@ -4,11 +4,13 @@ import "src/proto/config.proto";
 
 message Query {
     string line = 1;
-    string file = 2;
+    // file contains a list of regular expressions to match a file's path
+    // against. A file must match *all* given patterns.
+    repeated string file = 2;
     string repo = 3;
     string tags = 4;
     bool fold_case = 5;
-    string not_file = 6;
+    repeated string not_file = 6;
     string not_repo = 7;
     string not_tags = 8;
     int32 max_matches = 9;

--- a/test/tagsearch_test.cc
+++ b/test/tagsearch_test.cc
@@ -30,11 +30,13 @@ TEST(tagsearch_test, TagLinesFromQuery) {
        interpolated, and (b) in at least one case varies how it is
        anchored correctly. */
 
-    q.file_pat.reset(new RE2("models.py"));
+    q.file_pats.clear();
+    q.file_pats.emplace_back(new RE2("models.py"));
     r = tag_searcher::create_tag_line_regex_from_query(&q);
     ASSERT_EQ(r, "^(User)\t[^\t]*(models.py)[^\t]*\t");
 
-    q.file_pat.reset(new RE2("^models.py"));
+    q.file_pats.clear();
+    q.file_pats.emplace_back(new RE2("^models.py"));
     r = tag_searcher::create_tag_line_regex_from_query(&q);
     ASSERT_EQ(r, "^(User)\t(models.py)[^\t]*\t");
 
@@ -42,7 +44,7 @@ TEST(tagsearch_test, TagLinesFromQuery) {
     r = tag_searcher::create_tag_line_regex_from_query(&q);
     ASSERT_EQ(r, "^(User)\t(models.py)[^\t]*\t\\d+;\"\t.*(c).*$");
 
-    q.file_pat.reset();
+    q.file_pats.clear();
     r = tag_searcher::create_tag_line_regex_from_query(&q);
     ASSERT_EQ(r, "^(User)\t[^\t]+\t\\d+;\"\t.*(c).*$");
 }

--- a/tools/gopackagesdriver.sh
+++ b/tools/gopackagesdriver.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+export GOCODE_GOPACKAGESDRIVER=true
+exec bazel run -- @io_bazel_rules_go//go/tools/gopackagesdriver "${@}"


### PR DESCRIPTION
This PR fixes #378.

(This is probably easiest to review commit-by-commit. The first one was necessary to get anything building on the Macs I have access to, and the second isn't necessary but makes editing Bazel-y C++ and Go much more pleasant.)

Changing the `Query` proto to accept a repeated `file` (or `not_file`) is straightforward, with one slightly odd caveat. `FilenameOnly` queries did not make use of the `file` field but, for some reason, repurposed `line`. This is still true, but the `line` pattern is used as the "most important" one, since we don't support multiple bounds in a match (see https://github.com/livegrep/livegrep/pull/349).

The changes to _use_ the additional values are mostly boring loops where previously one check sufficed. The tagsearch changes might just be incorrect, though 😆

This doesn't include any frontend changes, but in the future we may want to "fix" the conditional rendering of the extension buttons to allow `path:` too (the [current heuristic](https://github.com/livegrep/livegrep/blob/7e86d05914b84199d25ebab964df2935d436db1e/web/src/codesearch/codesearch_ui.js#L614C8-L616) hides it more often than necessary).

<details>
<summary><h4>Example searches</h4></summary>

`path:c build`

<img width="517" alt="image" src="https://github.com/livegrep/livegrep/assets/243356/3d361a0f-cd25-46b6-b15d-a2cbfd548fad">

<hr>

Clicking the `.cc` button: `file:.cc path:c build`

<img width="481" alt="image" src="https://github.com/livegrep/livegrep/assets/243356/db627f83-3e03-4084-94e1-f4465e8f08fb">
</details>