### PR TITLE
ignore_symlinks option

### DIFF
--- a/src/fs_indexer.cc
+++ b/src/fs_indexer.cc
@@ -17,8 +17,9 @@ namespace fs = boost::filesystem;
 fs_indexer::fs_indexer(code_searcher *cs,
                        const string& repopath,
                        const string& name,
-                       const Metadata &metadata)
-    : cs_(cs), repopath_(repopath), name_(name) {
+                       const Metadata &metadata,
+                       const bool& ignore_symlinks)
+    : cs_(cs), repopath_(repopath), name_(name), ignore_symlinks_(ignore_symlinks) {
     tree_ = cs->open_tree(name, metadata, "");
 }
 
@@ -56,6 +57,9 @@ void fs_indexer::walk(const fs::path& path) {
                 itr != end_itr;
                 ++itr) {
             boost::system::error_code ec;
+            if (ignore_symlinks_ && fs::is_symlink(itr->path())) {
+                continue;
+            }
             if (fs::is_directory(itr->status(ec)) ) {
                 fs_indexer::walk(itr->path());
             } else if (fs::is_regular_file(itr->status(ec)) ) {

--- a/src/fs_indexer.h
+++ b/src/fs_indexer.h
@@ -21,7 +21,8 @@ public:
     fs_indexer(code_searcher *cs,
                const string& repopath,
                const string& name,
-               const Metadata &metadata);
+               const Metadata &metadata,
+               const bool& ignore_symlinks);
     ~fs_indexer();
     void walk(const boost::filesystem::path& path);
     void walk_contents_file(const boost::filesystem::path& contents_file_path);
@@ -30,6 +31,7 @@ protected:
     std::string repopath_;
     std::string name_;
     const indexed_tree *tree_;
+    bool ignore_symlinks_;
 
     void read_file(const boost::filesystem::path& path);
 };

--- a/src/proto/config.proto
+++ b/src/proto/config.proto
@@ -24,6 +24,7 @@ message PathSpec {
     string name = 2             [json_name = "name"];
     string ordered_contents = 3 [json_name = "ordered_contents"];
     Metadata metadata = 4       [json_name = "metadata"];
+    bool ignore_symlinks = 5    [json_name = "ignore_symlinks"];
 }
 
 message RepoSpec {

--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -96,7 +96,7 @@ void build_index(code_searcher *cs, const vector<std::string> &argv) {
     for (auto &path : spec.paths()) {
         fprintf(stderr, "Walking path_spec name=%s, path=%s\n",
                 path.name().c_str(), path.path().c_str());
-        fs_indexer indexer(cs, path.path(), path.name(), path.metadata());
+        fs_indexer indexer(cs, path.path(), path.name(), path.metadata(), path.ignore_symlinks());
         if (path.ordered_contents().empty()) {
             fprintf(stderr, "  walking full tree\n");
             indexer.walk(path.path());


### PR DESCRIPTION
Add an option to ignore symbolic links, off by default.

Some projects contain infinite symlink loops ([Example](https://github.com/jbruchon/jdupes/tree/master/testdir/recursed_a)) or symlinks that point outside the directory tree. The former just slows down indexing because the recursion stops after a certain maximum depth, while the latter can be a security issue in certain setups.

There are workarounds that don't require changing livegrep, such as a [filtering read-only FUSE](https://github.com/wfrisch/rofs-filtered), but IMHO it would be more comfortable to just have this option in livegrep itself.