### PR TITLE
Adding new GA4 tagging code snippets to common layout

### DIFF
--- a/web/templates/common/layout.html
+++ b/web/templates/common/layout.html
@@ -35,19 +35,16 @@
     {{if .Config.GoogleAnalyticsId}}
     <script{{.Nonce}} type="text/javascript">
 
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', '{{.Config.GoogleAnalyticsId}}', 'auto');
-      ga('send', 'pageview');
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','{{.Config.GoogleAnalyticsId}}');
 
     </script>
     {{end}}
     <link{{.Nonce}} rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Stripe Code Search" />
   </head>
   <body>
+    {{if .Config.GoogleAnalyticsId}}
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{.Config.GoogleAnalyticsId}}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {{end}}
     {{if .IncludeHeader}}
     <div id='header'>
       {{if .Config.HeaderHTML}}


### PR DESCRIPTION
## Context

Livegrep is still with the Google Analytics 3 mechanism of collecting data from the website according to the customer's ID. Since Google Analytics 4 was launched and the previous was deprecated, the data is not being collected properly. We must add the new method provided by GA platform in order to have analytics data being collected properly and sent to the customer's Google Analytics dashboard.

## Solution

I noticed that Livegrep uses Google Tag Manager instead of the basic method provided by Google Analytics 4. After some research, I found this [blog post](https://www.analyticsmania.com/post/how-to-install-google-tag-manager/) where we can identify that method provided by Google Tag Manager.

First, we have to change the previous implemented function inside the `<head>` tag to the new one. Then, we need to add a `<noscript>` tag right after the `<body>` tag opening.