### PR TITLE
Remove Stripe brand from opensearch.xml

### DIFF
--- a/web/templates/common/layout.html
+++ b/web/templates/common/layout.html
@@ -45,7 +45,7 @@
 
     </script>
     {{end}}
-    <link{{.Nonce}} rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Stripe Code Search" />
+    <link{{.Nonce}} rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Code Search" />
   </head>
   <body>
     {{if .IncludeHeader}}


### PR DESCRIPTION
This PR removes the Stripe keyword from the `<link rel=search>` tag for `opensearch.xml`.