### PR TITLE
Make window.scriptData initialization hashable

### DIFF
--- a/web/templates/common/layout.html
+++ b/web/templates/common/layout.html
@@ -15,8 +15,9 @@
     <link{{.Nonce}} rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/css/bootstrap-select.min.css" integrity="sha256-/us3egi2cVp0mEkVR8cnqLsuDY6BmrDuvTPUuEr1HJQ=" crossorigin="anonymous" />
     <script{{.Nonce}} src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.1.4/js.cookie.min.js" integrity="sha256-NjbogQqosWgor0UBdCURR5dzcvAgHnfUZMcZ8RCwkk8=" crossorigin="anonymous"></script>
     {{if .ScriptData}}
+    <script id="scriptDataJson" type="application/json">{{.ScriptData}}</script>
     <script{{.Nonce}}>
-      window.scriptData = {{.ScriptData}};
+      window.scriptData = JSON.parse(document.getElementById('scriptDataJson').textContent);
     </script>
     {{end}}
     {{if .ScriptName}}


### PR DESCRIPTION
This PR makes it possible to serve Livegrep content using a CSP policy that relies on hashes without using Nonce.

Previously, it was not possible to create a hash of the inline script that consumes `{{.ScriptData}}` because the data is dynamically generated and the hash is not stable. This inline script was the only `<script>` tag for which a hash cannot be computed.

With this PR, it's possible to compute the hash for the inline script because the dynamic data is stored in a harmless `application/json` block while the JS script tag has stable content.