### PR TITLE
Use pkg_tar from rules_pkg

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
 refresh_compile_commands(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -159,3 +159,15 @@ npm_translate_lock(
 load("@npm//:repositories.bzl", "npm_repositories")
 
 npm_repositories()
+
+http_archive(
+    name = "rules_pkg",
+    urls = [
+        "https://github.com/bazelbuild/rules_pkg/releases/download/1.0.0/rules_pkg-1.0.0.tar.gz",
+    ],
+    sha256 = "cad05f864a32799f6f9022891de91ac78f30e0fa07dc68abac92a628121b5b11",
+)
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()

--- a/cmd/BUILD
+++ b/cmd/BUILD
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 pkg_tar(
     name = "go_tools",

--- a/src/tools/BUILD
+++ b/src/tools/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 cc_library(
     name = "grpc_server",

--- a/web/BUILD
+++ b/web/BUILD
@@ -1,7 +1,7 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//web:webpack/package_json.bzl", webpack_bin = "bin")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
Add `rules_pkg` to use `pkg_tar` instead of using `pkg_tar` from `bazel_tools`, as this seems to fix [issue](https://github.com/livegrep/livegrep/issues/390) I reported about build not working on Ubuntu 24.04.

Including `rules_pkg` is also required to upgrade to later versions of Bazel (Bazel 6 and higher), since it was moved into its own repository.