### PR TITLE
Fix ordered contents example

### DIFF
--- a/doc/examples/livegrep/index_with_ordered_contents.json
+++ b/doc/examples/livegrep/index_with_ordered_contents.json
@@ -4,10 +4,10 @@
         {
             "name": "livegrep/livegrep",
             "path": "src/",
-            "ordered-contents": "ordered-contents.txt",
+            "ordered_contents": "ordered-contents.txt",
             "metadata": {
                 "url_pattern": "https://github.com/{name}/blob/{version}/src/{path}#L{lno}"
             }
         }
-    ],
+    ]
 }


### PR DESCRIPTION
In commit 74f24994, fields were renamed to use underscores instead of dashes, but in the ordered contents example, field `ordered-contents` wasn't updated. It now uses the same field present in `src/proto/config.proto`.

There was also a trailing comma at the end. For consistency with other examples, it was removed as well.