### PR TITLE
Fix the broken links on livegrep.com

### DIFF
--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -153,6 +153,8 @@ func main() {
 	}
 	if *flagRevparse {
 		args = append(args, "--revparse")
+	} else {
+		args = append(args, "--revparse=false")
 	}
 	if *flagSkipMissing {
 		args = append(args, "--skip-missing")

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -51,7 +51,7 @@ function shorten(ref) {
   var match = /^refs\/(tags|branches)\/(.*)/.exec(ref);
   if (match)
     return match[2];
-  match = /^([0-9a-f]{8})[0-9a-f]+$/.exec(ref);
+  match = /^([0-9a-f]{12})[0-9a-f]+$/.exec(ref);
   if (match)
     return match[1];
   // If reference is origin/foo, assume that foo is


### PR DESCRIPTION
Two separate fixes, either one should suffice, and I believe both are correct.