### PR TITLE
Add golang.org/x/sys to WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,7 +64,14 @@ go_rules_dependencies()
 
 go_register_toolchains(version = "1.19.2")
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+go_repository(
+    name = "org_golang_x_sys",
+    importpath = "golang.org/x/sys",
+    sum = "h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=",
+    version = "v0.33.0",
+)
 
 gazelle_dependencies()
 
@@ -113,10 +120,9 @@ git_repository(
 
 http_archive(
     name = "hedron_compile_commands",
-
-    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/e16062717d9b098c3c2ac95717d2b3e661c50608.tar.gz",
     sha256 = "ed5aea1dc87856aa2029cb6940a51511557c5cac3dbbcb05a4abd989862c36b4",
     strip_prefix = "bazel-compile-commands-extractor-e16062717d9b098c3c2ac95717d2b3e661c50608",
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/e16062717d9b098c3c2ac95717d2b3e661c50608.tar.gz",
 )
 
 load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
@@ -162,10 +168,10 @@ npm_repositories()
 
 http_archive(
     name = "rules_pkg",
+    sha256 = "cad05f864a32799f6f9022891de91ac78f30e0fa07dc68abac92a628121b5b11",
     urls = [
         "https://github.com/bazelbuild/rules_pkg/releases/download/1.0.0/rules_pkg-1.0.0.tar.gz",
     ],
-    sha256 = "cad05f864a32799f6f9022891de91ac78f30e0fa07dc68abac92a628121b5b11",
 )
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")


### PR DESCRIPTION
The result of:
```
bazel run //:gazelle -- update-repos golang.org/x/sys
```

This resolved an error of the form:
```
$ bazel build //...
[...snip...]
ERROR: /home/chromy/.cache/bazel/_bazel_chromy/ca4a0af3e2282fdc79af362ae706ecf4/external/org_golang_google_grpc/internal/syscall/BUILD.bazel:3:11: GoCompilePkg external/org_golang_google_grpc/internal/syscall/syscall.a failed: (Exit 1): builder failed: error executing command bazel-out/k8-opt-exec-2B5CBBC6/bin/external/go_sdk/builder compilepkg -sdk external/go_sdk -installsuffix linux_amd64 -src external/org_golang_google_grpc/internal/syscall/syscall_linux.go -src ... (remaining 23 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
compilepkg: missing strict dependencies:
        /home/chromy/.cache/bazel/_bazel_chromy/ca4a0af3e2282fdc79af362ae706ecf4/sandbox/linux-sandbox/3544/execroot/com_github_livegrep_livegrep/external/org_golang_google_grpc/internal/syscall/syscall_linux.go: import of "golang.org/x/sys/unix"
No dependencies were provided.
```

On the platform:
```
$ uname -a
Linux astra 6.1.0-27-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.115-1 (2024-11-01) x86_64 GNU/Linux
$ bazel --version
bazel 5.3.2
```

The command was suggested by:
https://stackoverflow.com/a/77743203/695467
but I don't understand go/bazel enough to know what that means.
