### PR TITLE
Update error to use correct flag name

### DIFF
--- a/cmd/livegrep-github-reindex/main.go
+++ b/cmd/livegrep-github-reindex/main.go
@@ -81,7 +81,7 @@ func main() {
 
 	if *flagInstallation {
 		if *flagGithubKey == "" {
-			log.Fatal("-installation-key requires passing a github key, via either -github-key or $GITHUB_KEY")
+			log.Fatal("-installation-token requires passing a github key, via either -github-key or $GITHUB_KEY")
 		}
 		*flagHTTP = true
 		*flagHTTPUsername = "x-access-token"


### PR DESCRIPTION
The error here refers to -installation-key, but the flag's name is actually -installation-token. This just fixes that up.