### PR TITLE
Improve web initial load with many repos

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -82,7 +82,7 @@ func (s *server) ServeRoot(ctx context.Context, w http.ResponseWriter, r *http.R
 
 type searchScriptData struct {
 	RepoUrls           map[string]map[string]string `json:"repo_urls"`
-	InternalViewRepos  map[string]config.RepoConfig `json:"internal_view_repos"`
+	InternalViewRepos  []string                     `json:"internal_view_repos"`
 	DefaultSearchRepos []string                     `json:"default_search_repos"`
 	LinkConfigs        []config.LinkConfig          `json:"link_configs"`
 }
@@ -106,7 +106,12 @@ func (s *server) makeSearchScriptData() (script_data *searchScriptData, backends
 		bk.I.Unlock()
 	}
 
-	script_data = &searchScriptData{urls, s.repos, s.config.DefaultSearchRepos, s.config.LinkConfigs}
+	internalRepoNames := make([]string, 0, len(s.repos))
+	for name := range s.repos {
+		internalRepoNames = append(internalRepoNames, name)
+	}
+
+	script_data = &searchScriptData{urls, internalRepoNames, s.config.DefaultSearchRepos, s.config.LinkConfigs}
 
 	return script_data, backends, sampleRepo
 }

--- a/web/src/codesearch/codesearch_ui.js
+++ b/web/src/codesearch/codesearch_ui.js
@@ -792,11 +792,6 @@ var CodesearchUI = function() {
           CodesearchUI.inputs_case.filter('[value=auto]').attr('checked', true);
       }
 
-      RepoSelector.init();
-      CodesearchUI.update_repo_options();
-
-      CodesearchUI.init_query();
-
       CodesearchUI.input.keydown(CodesearchUI.keypress);
       CodesearchUI.input.bind('paste', CodesearchUI.keypress);
       CodesearchUI.input.focus();
@@ -819,6 +814,14 @@ var CodesearchUI = function() {
       });
 
       CodesearchUI.toggle_context();
+
+      // Defer heavy repo dropdown initialization so the page can paint first.
+      // RepoSelector.init() creates the bootstrap-select widget (expensive with many repos).
+      setTimeout(function() {
+        RepoSelector.init();
+        CodesearchUI.update_repo_options();
+        CodesearchUI.init_query();
+      }, 0);
 
       Codesearch.connect(CodesearchUI);
       $('.query-hint code').click(function(e) {
@@ -1009,7 +1012,9 @@ var CodesearchUI = function() {
 }();
 
 CodesearchUI.repo_urls = initData.repo_urls;
-CodesearchUI.internalViewRepos = initData.internal_view_repos;
+var ivr = {};
+initData.internal_view_repos.forEach(function(name) { ivr[name] = true; });
+CodesearchUI.internalViewRepos = ivr;
 CodesearchUI.defaultSearchRepos = initData.default_search_repos;
 CodesearchUI.linkConfigs = (initData.link_configs || []).map(function(link_config) {
   if (link_config.whitelist_pattern) {

--- a/web/src/codesearch/repo_selector.js
+++ b/web/src/codesearch/repo_selector.js
@@ -37,6 +37,10 @@ function init() {
     });
 }
 
+function escapeHtml(str) {
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 function updateOptions(newOptions) {
     // Skip update if the options are the same, to avoid losing selected state.
     var currentOptions = [];
@@ -47,26 +51,32 @@ function updateOptions(newOptions) {
         return;
     }
 
-    $('#repos').empty();
+    newOptions.sort();
 
-    newOptions.sort()
-    var groups = new Map()
-    groups.set('/', $('#repos'))
-
+    // Build HTML string in one pass instead of creating DOM elements individually.
+    var html = '';
+    var currentGroup = null;
     for (var i = 0; i < newOptions.length; i++) {
-        var path = newOptions[i].split('/');
-        var group = path.slice(0, path.length - 1).join('/') + '/';
-        var option = path[path.length - 1];
+        var parts = newOptions[i].split('/');
+        var group = parts.slice(0, parts.length - 1).join('/') + '/';
+        var option = parts[parts.length - 1];
+        var value = group + option;
 
-        if (!groups.has(group)) {
-            var groupDOM = $('<optgroup>').attr('label', group)
-            $('#repos').append(groupDOM);
-            groups.set(group, groupDOM)
+        if (group !== '/' && group !== currentGroup) {
+            if (currentGroup !== null && currentGroup !== '/') {
+                html += '</optgroup>';
+            }
+            currentGroup = group;
+            html += '<optgroup label="' + escapeHtml(group) + '">';
         }
-        groups.get(group).append($('<option>').attr('value', group + option).text(option));
+
+        html += '<option value="' + escapeHtml(value) + '">' + escapeHtml(option) + '</option>';
+    }
+    if (currentGroup !== null && currentGroup !== '/') {
+        html += '</optgroup>';
     }
 
-    groups.clear()
+    $('#repos').html(html);
     $('#repos').selectpicker('refresh');
 }
 


### PR DESCRIPTION
We have 20k repos in our livegrep, which takes ~9s for initial page load. Mostly because of the perf of building so many DOM elements in a loop.

1. InternalViewRepos is only ever used as a hash lookup, so pass it over the wire as an array of strings
2. Defer repo dropdown initialization
3. Build the option list as a big HTML string

This brings the load time down to ~1s for such a large list.