### PR TITLE
Add MCP server for livegrep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ vendor/re2/obj/libre2.a
 /bazel-*
 compile_commands.json
 .devbox
+
+# Local MCP client config (copy from .mcp.json.example)
+.mcp.json

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "livegrep": {
+      "command": "/ABSOLUTE/PATH/TO/REPO/bazel-bin/cmd/livegrep-mcp-server/livegrep-mcp-server_/livegrep-mcp-server",
+      "args": ["-backend", "localhost:9999"]
+    }
+  }
+}

--- a/cmd/BUILD
+++ b/cmd/BUILD
@@ -9,6 +9,7 @@ pkg_tar(
             "livegrep",
             "livegrep-fetch-reindex",
             "livegrep-github-reindex",
+            "livegrep-mcp-server",
             "livegrep-reload",
         ]
     ],

--- a/cmd/livegrep-mcp-server/BUILD
+++ b/cmd/livegrep-mcp-server/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -9,6 +9,16 @@ go_library(
         "//src/proto:go_proto",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials/insecure:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//src/proto:go_proto",
+        "@org_golang_google_grpc//:go_default_library",
     ],
 )
 

--- a/cmd/livegrep-mcp-server/BUILD
+++ b/cmd/livegrep-mcp-server/BUILD
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/livegrep/livegrep/cmd/livegrep-mcp-server",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/proto:go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials/insecure:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "livegrep-mcp-server",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/livegrep-mcp-server/README.md
+++ b/cmd/livegrep-mcp-server/README.md
@@ -1,0 +1,169 @@
+# livegrep-mcp-server
+
+Give your AI assistant fast, regex-powered code search over your repositories.
+
+This is an [MCP](https://modelcontextprotocol.io/) server that connects an MCP
+client (Claude, your editor, etc.) to a livegrep `codesearch` backend. Once
+it's running, you can ask your assistant things like _"where do we call
+`grpc.Dial`?"_ or _"find files named codesearch"_ and it searches your indexed
+code instantly.
+
+```diagram
+╭──────────────╮   MCP/stdio   ╭───────────────────╮   gRPC    ╭──────────────╮
+│  MCP client  │──────────────▶│ livegrep-mcp-server│─────────▶│  codesearch  │
+│ (Claude/IDE) │◀──────────────│   (this program)   │◀─────────│   backend    │
+╰──────────────╯               ╰───────────────────╯           ╰──────────────╯
+```
+
+## Quick start
+
+Three steps and you're searching. (Run these from the repo root.)
+
+**1. Start a search backend.** The easiest way is Docker — no C++ toolchain
+needed:
+
+```sh
+docker compose up codesearch          # serves gRPC on localhost:9999
+```
+
+**2. Build this server** (a Go binary, builds in seconds):
+
+```sh
+bazel build //cmd/livegrep-mcp-server
+```
+
+**3. Point your MCP client at it.** Copy the template at the repo root and fill
+in your absolute path:
+
+```sh
+cp .mcp.json.example .mcp.json
+# then edit "command" to your repo's absolute binary path
+```
+
+```json
+{
+  "mcpServers": {
+    "livegrep": {
+      "command": "/ABSOLUTE/PATH/TO/REPO/bazel-bin/cmd/livegrep-mcp-server/livegrep-mcp-server_/livegrep-mcp-server",
+      "args": ["-backend", "localhost:9999"]
+    }
+  }
+}
+```
+
+`.mcp.json` is gitignored (it holds machine-specific paths);
+[`.mcp.json.example`](../../.mcp.json.example) is the committed template.
+
+> **Heads up:** MCP clients launch servers with a minimal `PATH`, so use the
+> **absolute path** to the built binary (not `bazel`/`bazelisk`). After a
+> `bazel clean`, rebuild with step 2.
+
+Reload your client's MCP servers and you're ready. Try: _"Using livegrep, list
+the indexed repositories."_
+
+## What you can ask
+
+Talk to your assistant naturally — it picks the right tool for you.
+
+| You say…                                                  | Tool used      |
+| --------------------------------------------------------- | -------------- |
+| "Search the code for `grpc\.Dial`"                        | `code_search`  |
+| "Find every TODO comment in the server package"           | `code_search`  |
+| "Find files whose path matches `codesearch`"              | `search_files` |
+| "What repositories are indexed?"                          | `get_repos`    |
+
+### Example results
+
+**"List the indexed repositories"** →
+
+```
+livegrep/livegrep   # the src/ tree (filesystem index)
+livegrep            # the whole repo at git HEAD
+```
+
+Both point at this repo — they're just two views defined in
+[`doc/examples/livegrep/index.json`](../../doc/examples/livegrep/index.json).
+
+**"Search the code for the regex `grpc\.Dial`"** →
+
+| File                               | Line | Content                                                               |
+| ---------------------------------- | ---- | -------------------------------------------------------------------- |
+| client/test/testutil.go            | 53   | `conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock())` |
+| cmd/livegrep-fetch-reindex/main.go | 363  | `client, err := grpc.Dial(addr, grpc.WithInsecure())`               |
+| cmd/livegrep-reload/main.go        | 26   | `client, err := grpc.Dial(addr, grpc.WithInsecure())`               |
+| server/backend.go                  | 37   | `client, err := grpc.Dial(addr, dialOpts...)`                       |
+
+**"Find files whose path matches `codesearch`"** →
+
+```
+src/codesearch.cc, src/codesearch.h, test/codesearch_test.cc,
+web/src/codesearch/codesearch_ui.js, ...
+```
+
+## Tools reference
+
+| Tool           | Description                            | Parameters                                                                                                                      |
+| -------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `code_search`  | Search code by regex pattern          | `query` (required), `repo`, `file`, `case_sensitive` (default false), `max_matches` (default 100), `context_lines` (default 2) |
+| `search_files` | Search for files by name/path pattern | `pattern` (required), `repo`, `max_matches` (default 100)                                                                       |
+| `get_repos`    | List indexed repositories             | _none_                                                                                                                          |
+
+- `code_search` returns each match with `repo`, `path`, `line`, `content`,
+  `match_bounds`, and surrounding `context_before`/`context_after` lines.
+- `search_files` returns `repo` and `path`.
+- Both include a `stats` block.
+- Bad input (missing `query`, invalid regex) comes back as a normal result with
+  `isError: true` — the server keeps running.
+
+## Troubleshooting
+
+| Symptom                                              | Cause & fix                                                                                                                                                                  |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Failed to reconnect … ENOENT`                      | The client can't find the `command`. Use the **absolute** path to the built binary in `.mcp.json` (not `bazel`/`bazelisk`), and build it first.                            |
+| `HTTP/2 framing` / `transport` error on a search    | `-backend` is pointing at something that isn't the gRPC backend. Check it's up (`docker compose ps`) and the port isn't taken by another process (`lsof -nP -iTCP:9999 -sTCP:LISTEN`). |
+| `connection refused`                                | No backend running. Start one: `docker compose up codesearch`.                                                                                                             |
+| Search finds 0 matches for code you just wrote      | The index reads the repo's **git HEAD**, so uncommitted changes aren't searchable yet (the `src/` view does see your working tree).                                        |
+| Port `9999` already in use                          | `CODESEARCH_PORT=19999 docker compose up codesearch`, then set `-backend localhost:19999` in `.mcp.json`.                                                                  |
+
+## Development
+
+### Build & test
+
+```sh
+bazel build //cmd/livegrep-mcp-server:livegrep-mcp-server
+bazel test  //cmd/livegrep-mcp-server:go_default_test
+```
+
+Unit tests run against a fake backend (`pb.CodeSearchClient`), so no live
+`codesearch` is needed.
+
+### Run the backend with Docker
+
+The repo-root [`docker-compose.yml`](../../docker-compose.yml) uses the public
+`livegrep/base` image (which ships the C++ `codesearch` binary) to index this
+repo:
+
+```sh
+docker compose up codesearch   # backend only, on localhost:9999
+docker compose up              # backend + web UI at http://localhost:8910
+```
+
+> The public images are `linux/amd64` (emulated on Apple Silicon) and don't
+> include `livegrep-mcp-server` — that's why you build it locally.
+
+### Run without a client (smoke test)
+
+The server speaks newline-delimited JSON-RPC 2.0 on stdio — pipe requests
+straight in (responses go to stdout, logs to stderr):
+
+```sh
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_repos","arguments":{}}}' \
+  | bazel-bin/cmd/livegrep-mcp-server/livegrep-mcp-server_/livegrep-mcp-server -backend localhost:9999 2>/dev/null
+```
+
+For a full automated check (starts a backend, runs assertions, tears down), see
+[`validate.sh`](validate.sh).

--- a/cmd/livegrep-mcp-server/main.go
+++ b/cmd/livegrep-mcp-server/main.go
@@ -1,0 +1,456 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	pb "github.com/livegrep/livegrep/src/proto/go_proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+var (
+	backendAddr = flag.String("backend", "localhost:9999", "codesearch gRPC address")
+)
+
+type CodeSearchArgs struct {
+	Query         string  `json:"query"`
+	Repo          string  `json:"repo"`
+	File          string  `json:"file"`
+	CaseSensitive bool    `json:"case_sensitive"`
+	MaxMatches    float64 `json:"max_matches"`
+	ContextLines  float64 `json:"context_lines"`
+}
+
+type SearchFileArgs struct {
+	Pattern    string  `json:"pattern"`
+	Repo       string  `json:"repo"`
+	MaxMatches float64 `json:"max_matches"`
+}
+
+type GetReposArgs struct{}
+
+type SearchResult struct {
+	Repo            string   `json:"repo"`
+	Path            string   `json:"path"`
+	Line            int64    `json:"line"`
+	Content         string   `json:"content"`
+	MatchBounds     [2]int   `json:"match_bounds"`
+	ContextBefore   []string `json:"context_before"`
+	ContextAfter    []string `json:"context_after"`
+}
+
+type SearchResponse struct {
+	Results []SearchResult            `json:"results"`
+	Stats   map[string]interface{} `json:"stats"`
+}
+
+type FileResult struct {
+	Repo  string `json:"repo"`
+	Path  string `json:"path"`
+}
+
+type FileSearchResponse struct {
+	Results []FileResult              `json:"results"`
+	Stats   map[string]interface{} `json:"stats"`
+}
+
+type RepoInfo struct {
+	Name string `json:"name"`
+}
+
+type RepoResponse struct {
+	Repos []RepoInfo `json:"repos"`
+}
+
+// JSON-RPC 2.0 types
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id,omitempty"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *JSONRPCError   `json:"error,omitempty"`
+}
+
+type JSONRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type ToolDescriptor struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	InputSchema map[string]interface{} `json:"inputSchema"`
+}
+
+type ToolsListResult struct {
+	Tools []ToolDescriptor `json:"tools"`
+}
+
+type ToolCallRequest struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments"`
+}
+
+var client pb.CodeSearchClient
+
+func sendResponse(w *bufio.Writer, id interface{}, result interface{}, errMsg *JSONRPCError) error {
+	resp := Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+		Error:   errMsg,
+	}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+func handleToolsList(w *bufio.Writer, id interface{}) error {
+	tools := []ToolDescriptor{
+		{
+			Name:        "code_search",
+			Description: "Search for code patterns using regex",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"query": map[string]interface{}{
+						"type":        "string",
+						"description": "Regex pattern to search for",
+					},
+					"repo": map[string]interface{}{
+						"type":        "string",
+						"description": "Filter by repository pattern (optional)",
+					},
+					"file": map[string]interface{}{
+						"type":        "string",
+						"description": "Filter by file path pattern (optional)",
+					},
+					"case_sensitive": map[string]interface{}{
+						"type":        "boolean",
+						"description": "Case-sensitive search (default false)",
+					},
+					"max_matches": map[string]interface{}{
+						"type":        "number",
+						"description": "Maximum number of matches to return (default 100)",
+					},
+					"context_lines": map[string]interface{}{
+						"type":        "number",
+						"description": "Number of context lines to include (default 2)",
+					},
+				},
+				"required": []string{"query"},
+			},
+		},
+		{
+			Name:        "search_files",
+			Description: "Search for files by name or path pattern",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"pattern": map[string]interface{}{
+						"type":        "string",
+						"description": "File path regex pattern to search",
+					},
+					"repo": map[string]interface{}{
+						"type":        "string",
+						"description": "Filter by repository pattern (optional)",
+					},
+					"max_matches": map[string]interface{}{
+						"type":        "number",
+						"description": "Maximum number of matches to return (default 100)",
+					},
+				},
+				"required": []string{"pattern"},
+			},
+		},
+		{
+			Name:        "get_repos",
+			Description: "List all indexed repositories",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+				"required":   []string{},
+			},
+		},
+	}
+
+	return sendResponse(w, id, ToolsListResult{Tools: tools}, nil)
+}
+
+func handleToolCall(w *bufio.Writer, id interface{}, call ToolCallRequest) error {
+	switch call.Name {
+	case "code_search":
+		return handleCodeSearch(w, id, call.Arguments)
+	case "search_files":
+		return handleSearchFiles(w, id, call.Arguments)
+	case "get_repos":
+		return handleGetRepos(w, id, call.Arguments)
+	default:
+		return sendResponse(w, id, nil, &JSONRPCError{
+			Code:    -32601,
+			Message: fmt.Sprintf("Method not found: %s", call.Name),
+		})
+	}
+}
+
+func handleInitialize(w *bufio.Writer, id interface{}) error {
+	result := map[string]interface{}{
+		"protocolVersion": "2024-11-05",
+		"capabilities": map[string]interface{}{
+			"tools": map[string]interface{}{},
+		},
+		"serverInfo": map[string]interface{}{
+			"name":    "livegrep-mcp-server",
+			"version": "1.0.0",
+		},
+	}
+	return sendResponse(w, id, result, nil)
+}
+
+func handleCodeSearch(w *bufio.Writer, id interface{}, args map[string]interface{}) error {
+	var searchArgs CodeSearchArgs
+	if data, err := json.Marshal(args); err != nil {
+		return sendResponse(w, id, nil, &JSONRPCError{Code: -32600, Message: "Invalid request"})
+	} else if err := json.Unmarshal(data, &searchArgs); err != nil {
+		return sendResponse(w, id, nil, &JSONRPCError{Code: -32600, Message: "Invalid arguments"})
+	}
+
+	if searchArgs.Query == "" {
+		return sendResponse(w, id, nil, &JSONRPCError{Code: -32602, Message: "query parameter is required"})
+	}
+
+	log.Printf("[%v] Code search query=%q repo=%q file=%q case_sensitive=%v max_matches=%v", id, searchArgs.Query, searchArgs.Repo, searchArgs.File, searchArgs.CaseSensitive, searchArgs.MaxMatches)
+
+	q := &pb.Query{
+		Line:       searchArgs.Query,
+		MaxMatches: 100,
+	}
+
+	if searchArgs.Repo != "" {
+		q.Repo = searchArgs.Repo
+	}
+
+	if searchArgs.File != "" {
+		q.File = []string{searchArgs.File}
+	}
+
+	q.FoldCase = !searchArgs.CaseSensitive
+
+	if searchArgs.MaxMatches > 0 {
+		q.MaxMatches = int32(searchArgs.MaxMatches)
+	}
+
+	if searchArgs.ContextLines > 0 {
+		q.ContextLines = int32(searchArgs.ContextLines)
+	} else {
+		q.ContextLines = 2
+	}
+
+	searchCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := client.Search(searchCtx, q)
+	if err != nil {
+		return sendResponse(w, id, nil, &JSONRPCError{
+			Code:    -32603,
+			Message: fmt.Sprintf("Internal error: %v", err),
+		})
+	}
+
+	results := make([]SearchResult, 0)
+	for _, r := range result.Results {
+		results = append(results, SearchResult{
+			Repo:          r.Tree,
+			Path:          r.Path,
+			Line:          r.LineNumber,
+			Content:       r.Line,
+			MatchBounds:   [2]int{int(r.Bounds.Left), int(r.Bounds.Right)},
+			ContextBefore: r.ContextBefore,
+			ContextAfter:  r.ContextAfter,
+		})
+	}
+
+	response := SearchResponse{
+		Results: results,
+		Stats: map[string]interface{}{
+			"total_matches": len(results),
+			"search_time_ms": result.Stats.GetAnalyzeTime() + result.Stats.GetRe2Time(),
+		},
+	}
+
+	log.Printf("[%v] Code search completed: %d matches", id, len(results))
+	return sendResponse(w, id, response, nil)
+}
+
+func handleSearchFiles(w *bufio.Writer, id interface{}, args map[string]interface{}) error {
+	var searchArgs SearchFileArgs
+	if data, err := json.Marshal(args); err != nil {
+		return sendResponse(w, id, nil, &JSONRPCError{Code: -32600, Message: "Invalid request"})
+	} else if err := json.Unmarshal(data, &searchArgs); err != nil {
+		return sendResponse(w, id, nil, &JSONRPCError{Code: -32600, Message: "Invalid arguments"})
+	}
+
+	if searchArgs.Pattern == "" {
+		return sendResponse(w, id, nil, &JSONRPCError{Code: -32602, Message: "pattern parameter is required"})
+	}
+
+	log.Printf("[%v] File search pattern=%q repo=%q max_matches=%v", id, searchArgs.Pattern, searchArgs.Repo, searchArgs.MaxMatches)
+
+	q := &pb.Query{
+		Line:         searchArgs.Pattern,
+		FilenameOnly: true,
+		MaxMatches:   100,
+	}
+
+	if searchArgs.Repo != "" {
+		q.Repo = searchArgs.Repo
+	}
+
+	if searchArgs.MaxMatches > 0 {
+		q.MaxMatches = int32(searchArgs.MaxMatches)
+	}
+
+	searchCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := client.Search(searchCtx, q)
+	if err != nil {
+		return sendResponse(w, id, nil, &JSONRPCError{
+			Code:    -32603,
+			Message: fmt.Sprintf("Internal error: %v", err),
+		})
+	}
+
+	results := make([]FileResult, 0)
+	for _, r := range result.FileResults {
+		results = append(results, FileResult{
+			Repo: r.Tree,
+			Path: r.Path,
+		})
+	}
+
+	response := FileSearchResponse{
+		Results: results,
+		Stats: map[string]interface{}{
+			"total_matches": len(results),
+		},
+	}
+
+	log.Printf("[%v] File search completed: %d matches", id, len(results))
+	return sendResponse(w, id, response, nil)
+}
+
+func handleGetRepos(w *bufio.Writer, id interface{}, args map[string]interface{}) error {
+	log.Printf("[%v] Getting available repositories", id)
+	repoCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	info, err := client.Info(repoCtx, &pb.InfoRequest{})
+	if err != nil {
+		log.Printf("[%v] Failed to get repos: %v", id, err)
+		return sendResponse(w, id, nil, &JSONRPCError{
+			Code:    -32603,
+			Message: fmt.Sprintf("Internal error: %v", err),
+		})
+	}
+
+	repos := make([]RepoInfo, 0)
+	for _, tree := range info.Trees {
+		repos = append(repos, RepoInfo{Name: tree.Name})
+	}
+
+	log.Printf("[%v] Found %d repositories", id, len(repos))
+	response := RepoResponse{Repos: repos}
+	return sendResponse(w, id, response, nil)
+}
+
+func main() {
+	flag.Parse()
+
+	log.SetOutput(os.Stderr)
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	log.Printf("Connecting to codesearch at %s", *backendAddr)
+	conn, err := grpc.Dial(*backendAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("Failed to connect to codesearch: %v", err)
+	}
+	defer conn.Close()
+
+	client = pb.NewCodeSearchClient(conn)
+	log.Printf("Connected to codesearch backend")
+
+	scanner := bufio.NewScanner(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+
+	for scanner.Scan() {
+		var req Request
+		line := scanner.Bytes()
+
+		if err := json.Unmarshal(line, &req); err != nil {
+			log.Printf("Failed to parse request: %v", err)
+			sendResponse(writer, nil, nil, &JSONRPCError{
+				Code:    -32700,
+				Message: "Parse error",
+			})
+			continue
+		}
+
+		log.Printf("[%v] Received %s request", req.ID, req.Method)
+
+		if req.JSONRPC != "2.0" {
+			log.Printf("Invalid JSON-RPC version: %s", req.JSONRPC)
+			sendResponse(writer, req.ID, nil, &JSONRPCError{
+				Code:    -32600,
+				Message: "Invalid Request",
+			})
+			continue
+		}
+
+		switch req.Method {
+		case "initialize":
+			log.Printf("[%v] Handling initialize", req.ID)
+			handleInitialize(writer, req.ID)
+		case "tools/list":
+			log.Printf("[%v] Listing available tools", req.ID)
+			handleToolsList(writer, req.ID)
+		case "tools/call":
+			var call ToolCallRequest
+			if err := json.Unmarshal(req.Params, &call); err != nil {
+				log.Printf("[%v] Failed to parse tool call: %v", req.ID, err)
+				sendResponse(writer, req.ID, nil, &JSONRPCError{
+					Code:    -32600,
+					Message: "Invalid arguments",
+				})
+			} else {
+				log.Printf("[%v] Calling tool: %s with args: %v", req.ID, call.Name, call.Arguments)
+				handleToolCall(writer, req.ID, call)
+				log.Printf("[%v] Tool call completed", req.ID)
+			}
+		default:
+			log.Printf("Unknown method: %s", req.Method)
+			sendResponse(writer, req.ID, nil, &JSONRPCError{
+				Code:    -32601,
+				Message: "Method not found",
+			})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Scanner error: %v", err)
+	}
+}

--- a/cmd/livegrep-mcp-server/main.go
+++ b/cmd/livegrep-mcp-server/main.go
@@ -1,11 +1,15 @@
+// Command livegrep-mcp-server exposes a livegrep codesearch backend over the
+// Model Context Protocol (MCP) using newline-delimited JSON-RPC 2.0 on stdio.
 package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -15,9 +19,22 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-var (
-	backendAddr = flag.String("backend", "localhost:9999", "codesearch gRPC address")
+const (
+	protocolVersion = "2024-11-05"
+	serverName      = "livegrep-mcp-server"
+	serverVersion   = "1.0.0"
+
+	defaultMaxMatches   = 100
+	defaultContextLines = 2
+	searchTimeout       = 30 * time.Second
+	infoTimeout         = 10 * time.Second
 )
+
+var backendAddr = flag.String("backend", "localhost:9999", "codesearch gRPC address")
+
+// ---------------------------------------------------------------------------
+// Tool argument and result types
+// ---------------------------------------------------------------------------
 
 type CodeSearchArgs struct {
 	Query         string  `json:"query"`
@@ -34,30 +51,28 @@ type SearchFileArgs struct {
 	MaxMatches float64 `json:"max_matches"`
 }
 
-type GetReposArgs struct{}
-
 type SearchResult struct {
-	Repo            string   `json:"repo"`
-	Path            string   `json:"path"`
-	Line            int64    `json:"line"`
-	Content         string   `json:"content"`
-	MatchBounds     [2]int   `json:"match_bounds"`
-	ContextBefore   []string `json:"context_before"`
-	ContextAfter    []string `json:"context_after"`
+	Repo          string   `json:"repo"`
+	Path          string   `json:"path"`
+	Line          int64    `json:"line"`
+	Content       string   `json:"content"`
+	MatchBounds   [2]int   `json:"match_bounds"`
+	ContextBefore []string `json:"context_before"`
+	ContextAfter  []string `json:"context_after"`
 }
 
 type SearchResponse struct {
-	Results []SearchResult            `json:"results"`
+	Results []SearchResult         `json:"results"`
 	Stats   map[string]interface{} `json:"stats"`
 }
 
 type FileResult struct {
-	Repo  string `json:"repo"`
-	Path  string `json:"path"`
+	Repo string `json:"repo"`
+	Path string `json:"path"`
 }
 
 type FileSearchResponse struct {
-	Results []FileResult              `json:"results"`
+	Results []FileResult           `json:"results"`
 	Stats   map[string]interface{} `json:"stats"`
 }
 
@@ -69,7 +84,10 @@ type RepoResponse struct {
 	Repos []RepoInfo `json:"repos"`
 }
 
-// JSON-RPC 2.0 types
+// ---------------------------------------------------------------------------
+// JSON-RPC 2.0 / MCP protocol types
+// ---------------------------------------------------------------------------
+
 type Request struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      interface{}     `json:"id"`
@@ -78,10 +96,10 @@ type Request struct {
 }
 
 type Response struct {
-	JSONRPC string          `json:"jsonrpc"`
-	ID      interface{}     `json:"id,omitempty"`
-	Result  interface{}     `json:"result,omitempty"`
-	Error   *JSONRPCError   `json:"error,omitempty"`
+	JSONRPC string        `json:"jsonrpc"`
+	ID      interface{}   `json:"id"`
+	Result  interface{}   `json:"result,omitempty"`
+	Error   *JSONRPCError `json:"error,omitempty"`
 }
 
 type JSONRPCError struct {
@@ -104,22 +122,128 @@ type ToolCallRequest struct {
 	Arguments map[string]interface{} `json:"arguments"`
 }
 
-var client pb.CodeSearchClient
-
-func sendResponse(w *bufio.Writer, id interface{}, result interface{}, errMsg *JSONRPCError) error {
-	resp := Response{
-		JSONRPC: "2.0",
-		ID:      id,
-		Result:  result,
-		Error:   errMsg,
-	}
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		return err
-	}
-	return w.Flush()
+// ToolContent and ToolCallResult model the MCP tools/call result envelope.
+type ToolContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
 }
 
-func handleToolsList(w *bufio.Writer, id interface{}) error {
+type ToolCallResult struct {
+	Content []ToolContent `json:"content"`
+	IsError bool          `json:"isError,omitempty"`
+}
+
+// JSON-RPC standard error codes.
+const (
+	errParse          = -32700
+	errInvalidRequest = -32600
+	errMethodNotFound = -32601
+)
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+// Server handles MCP requests, delegating searches to a codesearch backend.
+// The backend is the generated pb.CodeSearchClient interface so it can be
+// replaced with a fake in tests.
+type Server struct {
+	client pb.CodeSearchClient
+}
+
+func NewServer(client pb.CodeSearchClient) *Server {
+	return &Server{client: client}
+}
+
+// Serve reads newline-delimited JSON-RPC requests from in and writes responses
+// to out until in is exhausted (EOF) or a read/write error occurs.
+func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
+	reader := bufio.NewReader(in)
+	encoder := json.NewEncoder(out)
+
+	for {
+		line, err := reader.ReadBytes('\n')
+		if trimmed := bytes.TrimSpace(line); len(trimmed) > 0 {
+			if resp := s.process(ctx, trimmed); resp != nil {
+				if encErr := encoder.Encode(resp); encErr != nil {
+					return encErr
+				}
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+// process parses a single JSON-RPC message and returns the response to send,
+// or nil if the message is a notification that requires no response.
+func (s *Server) process(ctx context.Context, line []byte) *Response {
+	var req Request
+	if err := json.Unmarshal(line, &req); err != nil {
+		log.Printf("parse error: %v", err)
+		return errorResponse(nil, errParse, "Parse error")
+	}
+	return s.handleRequest(ctx, &req)
+}
+
+// handleRequest dispatches a parsed request. It returns nil for notifications
+// (any method under "notifications/", or any request without an id), which per
+// the JSON-RPC spec must not receive a response.
+func (s *Server) handleRequest(ctx context.Context, req *Request) *Response {
+	isNotification := req.ID == nil
+
+	if req.JSONRPC != "2.0" {
+		if isNotification {
+			return nil
+		}
+		log.Printf("invalid JSON-RPC version: %q", req.JSONRPC)
+		return errorResponse(req.ID, errInvalidRequest, "Invalid Request")
+	}
+
+	log.Printf("[%v] %s", req.ID, req.Method)
+
+	switch req.Method {
+	case "initialize":
+		return s.handleInitialize(req.ID)
+	case "notifications/initialized":
+		return nil
+	case "ping":
+		return successResponse(req.ID, struct{}{})
+	case "tools/list":
+		return s.handleToolsList(req.ID)
+	case "tools/call":
+		var call ToolCallRequest
+		if err := json.Unmarshal(req.Params, &call); err != nil {
+			return errorResponse(req.ID, errInvalidRequest, "Invalid arguments")
+		}
+		return s.handleToolCall(ctx, req.ID, call)
+	default:
+		if isNotification {
+			return nil
+		}
+		log.Printf("unknown method: %s", req.Method)
+		return errorResponse(req.ID, errMethodNotFound, "Method not found")
+	}
+}
+
+func (s *Server) handleInitialize(id interface{}) *Response {
+	return successResponse(id, map[string]interface{}{
+		"protocolVersion": protocolVersion,
+		"capabilities": map[string]interface{}{
+			"tools": map[string]interface{}{},
+		},
+		"serverInfo": map[string]interface{}{
+			"name":    serverName,
+			"version": serverVersion,
+		},
+	})
+}
+
+func (s *Server) handleToolsList(id interface{}) *Response {
 	tools := []ToolDescriptor{
 		{
 			Name:        "code_search",
@@ -187,195 +311,202 @@ func handleToolsList(w *bufio.Writer, id interface{}) error {
 			},
 		},
 	}
-
-	return sendResponse(w, id, ToolsListResult{Tools: tools}, nil)
+	return successResponse(id, ToolsListResult{Tools: tools})
 }
 
-func handleToolCall(w *bufio.Writer, id interface{}, call ToolCallRequest) error {
+func (s *Server) handleToolCall(ctx context.Context, id interface{}, call ToolCallRequest) *Response {
+	var (
+		payload interface{}
+		err     error
+	)
 	switch call.Name {
 	case "code_search":
-		return handleCodeSearch(w, id, call.Arguments)
+		payload, err = s.codeSearch(ctx, call.Arguments)
 	case "search_files":
-		return handleSearchFiles(w, id, call.Arguments)
+		payload, err = s.searchFiles(ctx, call.Arguments)
 	case "get_repos":
-		return handleGetRepos(w, id, call.Arguments)
+		payload, err = s.getRepos(ctx)
 	default:
-		return sendResponse(w, id, nil, &JSONRPCError{
-			Code:    -32601,
-			Message: fmt.Sprintf("Method not found: %s", call.Name),
-		})
+		return errorResponse(id, errMethodNotFound, fmt.Sprintf("Unknown tool: %s", call.Name))
 	}
+	return toolResponse(id, payload, err)
 }
 
-func handleInitialize(w *bufio.Writer, id interface{}) error {
-	result := map[string]interface{}{
-		"protocolVersion": "2024-11-05",
-		"capabilities": map[string]interface{}{
-			"tools": map[string]interface{}{},
-		},
-		"serverInfo": map[string]interface{}{
-			"name":    "livegrep-mcp-server",
-			"version": "1.0.0",
-		},
-	}
-	return sendResponse(w, id, result, nil)
-}
+// ---------------------------------------------------------------------------
+// Tool implementations
+// ---------------------------------------------------------------------------
 
-func handleCodeSearch(w *bufio.Writer, id interface{}, args map[string]interface{}) error {
-	var searchArgs CodeSearchArgs
-	if data, err := json.Marshal(args); err != nil {
-		return sendResponse(w, id, nil, &JSONRPCError{Code: -32600, Message: "Invalid request"})
-	} else if err := json.Unmarshal(data, &searchArgs); err != nil {
-		return sendResponse(w, id, nil, &JSONRPCError{Code: -32600, Message: "Invalid arguments"})
+func (s *Server) codeSearch(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	var a CodeSearchArgs
+	if err := decodeArgs(args, &a); err != nil {
+		return nil, err
+	}
+	if a.Query == "" {
+		return nil, fmt.Errorf("query parameter is required")
 	}
 
-	if searchArgs.Query == "" {
-		return sendResponse(w, id, nil, &JSONRPCError{Code: -32602, Message: "query parameter is required"})
-	}
-
-	log.Printf("[%v] Code search query=%q repo=%q file=%q case_sensitive=%v max_matches=%v", id, searchArgs.Query, searchArgs.Repo, searchArgs.File, searchArgs.CaseSensitive, searchArgs.MaxMatches)
+	log.Printf("code_search query=%q repo=%q file=%q case_sensitive=%v max_matches=%v",
+		a.Query, a.Repo, a.File, a.CaseSensitive, a.MaxMatches)
 
 	q := &pb.Query{
-		Line:       searchArgs.Query,
-		MaxMatches: 100,
+		Line:         a.Query,
+		Repo:         a.Repo,
+		FoldCase:     !a.CaseSensitive,
+		MaxMatches:   defaultMaxMatches,
+		ContextLines: defaultContextLines,
+	}
+	if a.File != "" {
+		q.File = []string{a.File}
+	}
+	if a.MaxMatches > 0 {
+		q.MaxMatches = int32(a.MaxMatches)
+	}
+	if a.ContextLines > 0 {
+		q.ContextLines = int32(a.ContextLines)
 	}
 
-	if searchArgs.Repo != "" {
-		q.Repo = searchArgs.Repo
-	}
-
-	if searchArgs.File != "" {
-		q.File = []string{searchArgs.File}
-	}
-
-	q.FoldCase = !searchArgs.CaseSensitive
-
-	if searchArgs.MaxMatches > 0 {
-		q.MaxMatches = int32(searchArgs.MaxMatches)
-	}
-
-	if searchArgs.ContextLines > 0 {
-		q.ContextLines = int32(searchArgs.ContextLines)
-	} else {
-		q.ContextLines = 2
-	}
-
-	searchCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	searchCtx, cancel := context.WithTimeout(ctx, searchTimeout)
 	defer cancel()
 
-	result, err := client.Search(searchCtx, q)
+	result, err := s.client.Search(searchCtx, q)
 	if err != nil {
-		return sendResponse(w, id, nil, &JSONRPCError{
-			Code:    -32603,
-			Message: fmt.Sprintf("Internal error: %v", err),
-		})
+		return nil, fmt.Errorf("search failed: %w", err)
 	}
 
-	results := make([]SearchResult, 0)
+	results := make([]SearchResult, 0, len(result.Results))
 	for _, r := range result.Results {
+		var bounds [2]int
+		if r.Bounds != nil {
+			bounds = [2]int{int(r.Bounds.Left), int(r.Bounds.Right)}
+		}
 		results = append(results, SearchResult{
 			Repo:          r.Tree,
 			Path:          r.Path,
 			Line:          r.LineNumber,
 			Content:       r.Line,
-			MatchBounds:   [2]int{int(r.Bounds.Left), int(r.Bounds.Right)},
+			MatchBounds:   bounds,
 			ContextBefore: r.ContextBefore,
 			ContextAfter:  r.ContextAfter,
 		})
 	}
 
-	response := SearchResponse{
+	log.Printf("code_search completed: %d matches", len(results))
+	return SearchResponse{
 		Results: results,
 		Stats: map[string]interface{}{
-			"total_matches": len(results),
+			"total_matches":  len(results),
 			"search_time_ms": result.Stats.GetAnalyzeTime() + result.Stats.GetRe2Time(),
 		},
-	}
-
-	log.Printf("[%v] Code search completed: %d matches", id, len(results))
-	return sendResponse(w, id, response, nil)
+	}, nil
 }
 
-func handleSearchFiles(w *bufio.Writer, id interface{}, args map[string]interface{}) error {
-	var searchArgs SearchFileArgs
-	if data, err := json.Marshal(args); err != nil {
-		return sendResponse(w, id, nil, &JSONRPCError{Code: -32600, Message: "Invalid request"})
-	} else if err := json.Unmarshal(data, &searchArgs); err != nil {
-		return sendResponse(w, id, nil, &JSONRPCError{Code: -32600, Message: "Invalid arguments"})
+func (s *Server) searchFiles(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	var a SearchFileArgs
+	if err := decodeArgs(args, &a); err != nil {
+		return nil, err
+	}
+	if a.Pattern == "" {
+		return nil, fmt.Errorf("pattern parameter is required")
 	}
 
-	if searchArgs.Pattern == "" {
-		return sendResponse(w, id, nil, &JSONRPCError{Code: -32602, Message: "pattern parameter is required"})
-	}
-
-	log.Printf("[%v] File search pattern=%q repo=%q max_matches=%v", id, searchArgs.Pattern, searchArgs.Repo, searchArgs.MaxMatches)
+	log.Printf("search_files pattern=%q repo=%q max_matches=%v", a.Pattern, a.Repo, a.MaxMatches)
 
 	q := &pb.Query{
-		Line:         searchArgs.Pattern,
+		Line:         a.Pattern,
+		Repo:         a.Repo,
 		FilenameOnly: true,
-		MaxMatches:   100,
+		MaxMatches:   defaultMaxMatches,
+	}
+	if a.MaxMatches > 0 {
+		q.MaxMatches = int32(a.MaxMatches)
 	}
 
-	if searchArgs.Repo != "" {
-		q.Repo = searchArgs.Repo
-	}
-
-	if searchArgs.MaxMatches > 0 {
-		q.MaxMatches = int32(searchArgs.MaxMatches)
-	}
-
-	searchCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	searchCtx, cancel := context.WithTimeout(ctx, searchTimeout)
 	defer cancel()
 
-	result, err := client.Search(searchCtx, q)
+	result, err := s.client.Search(searchCtx, q)
 	if err != nil {
-		return sendResponse(w, id, nil, &JSONRPCError{
-			Code:    -32603,
-			Message: fmt.Sprintf("Internal error: %v", err),
-		})
+		return nil, fmt.Errorf("search failed: %w", err)
 	}
 
-	results := make([]FileResult, 0)
+	results := make([]FileResult, 0, len(result.FileResults))
 	for _, r := range result.FileResults {
-		results = append(results, FileResult{
-			Repo: r.Tree,
-			Path: r.Path,
-		})
+		results = append(results, FileResult{Repo: r.Tree, Path: r.Path})
 	}
 
-	response := FileSearchResponse{
+	log.Printf("search_files completed: %d matches", len(results))
+	return FileSearchResponse{
 		Results: results,
 		Stats: map[string]interface{}{
 			"total_matches": len(results),
 		},
-	}
-
-	log.Printf("[%v] File search completed: %d matches", id, len(results))
-	return sendResponse(w, id, response, nil)
+	}, nil
 }
 
-func handleGetRepos(w *bufio.Writer, id interface{}, args map[string]interface{}) error {
-	log.Printf("[%v] Getting available repositories", id)
-	repoCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+func (s *Server) getRepos(ctx context.Context) (interface{}, error) {
+	log.Printf("get_repos")
+
+	infoCtx, cancel := context.WithTimeout(ctx, infoTimeout)
 	defer cancel()
 
-	info, err := client.Info(repoCtx, &pb.InfoRequest{})
+	info, err := s.client.Info(infoCtx, &pb.InfoRequest{})
 	if err != nil {
-		log.Printf("[%v] Failed to get repos: %v", id, err)
-		return sendResponse(w, id, nil, &JSONRPCError{
-			Code:    -32603,
-			Message: fmt.Sprintf("Internal error: %v", err),
-		})
+		return nil, fmt.Errorf("info failed: %w", err)
 	}
 
-	repos := make([]RepoInfo, 0)
+	repos := make([]RepoInfo, 0, len(info.Trees))
 	for _, tree := range info.Trees {
 		repos = append(repos, RepoInfo{Name: tree.Name})
 	}
 
-	log.Printf("[%v] Found %d repositories", id, len(repos))
-	response := RepoResponse{Repos: repos}
-	return sendResponse(w, id, response, nil)
+	log.Printf("get_repos completed: %d repositories", len(repos))
+	return RepoResponse{Repos: repos}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// decodeArgs converts the loosely-typed MCP argument map into a typed struct.
+func decodeArgs(args map[string]interface{}, dst interface{}) error {
+	data, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Errorf("invalid arguments: %w", err)
+	}
+	if err := json.Unmarshal(data, dst); err != nil {
+		return fmt.Errorf("invalid arguments: %w", err)
+	}
+	return nil
+}
+
+func successResponse(id interface{}, result interface{}) *Response {
+	return &Response{JSONRPC: "2.0", ID: id, Result: result}
+}
+
+func errorResponse(id interface{}, code int, message string) *Response {
+	return &Response{JSONRPC: "2.0", ID: id, Error: &JSONRPCError{Code: code, Message: message}}
+}
+
+// toolResponse wraps a tool's payload (or error) in the MCP tools/call result
+// envelope. Tool errors are reported as a successful JSON-RPC response with
+// isError set, per the MCP specification.
+func toolResponse(id interface{}, payload interface{}, err error) *Response {
+	if err != nil {
+		return successResponse(id, ToolCallResult{
+			Content: []ToolContent{{Type: "text", Text: err.Error()}},
+			IsError: true,
+		})
+	}
+	data, marshalErr := json.MarshalIndent(payload, "", "  ")
+	if marshalErr != nil {
+		return successResponse(id, ToolCallResult{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("failed to encode result: %v", marshalErr)}},
+			IsError: true,
+		})
+	}
+	return successResponse(id, ToolCallResult{
+		Content: []ToolContent{{Type: "text", Text: string(data)}},
+	})
 }
 
 func main() {
@@ -384,73 +515,17 @@ func main() {
 	log.SetOutput(os.Stderr)
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
-	log.Printf("Connecting to codesearch at %s", *backendAddr)
-	conn, err := grpc.Dial(*backendAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	log.Printf("connecting to codesearch at %s", *backendAddr)
+	conn, err := grpc.NewClient(*backendAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		log.Fatalf("Failed to connect to codesearch: %v", err)
+		log.Fatalf("failed to create codesearch client: %v", err)
 	}
 	defer conn.Close()
 
-	client = pb.NewCodeSearchClient(conn)
-	log.Printf("Connected to codesearch backend")
+	srv := NewServer(pb.NewCodeSearchClient(conn))
+	log.Printf("serving MCP on stdio")
 
-	scanner := bufio.NewScanner(os.Stdin)
-	writer := bufio.NewWriter(os.Stdout)
-
-	for scanner.Scan() {
-		var req Request
-		line := scanner.Bytes()
-
-		if err := json.Unmarshal(line, &req); err != nil {
-			log.Printf("Failed to parse request: %v", err)
-			sendResponse(writer, nil, nil, &JSONRPCError{
-				Code:    -32700,
-				Message: "Parse error",
-			})
-			continue
-		}
-
-		log.Printf("[%v] Received %s request", req.ID, req.Method)
-
-		if req.JSONRPC != "2.0" {
-			log.Printf("Invalid JSON-RPC version: %s", req.JSONRPC)
-			sendResponse(writer, req.ID, nil, &JSONRPCError{
-				Code:    -32600,
-				Message: "Invalid Request",
-			})
-			continue
-		}
-
-		switch req.Method {
-		case "initialize":
-			log.Printf("[%v] Handling initialize", req.ID)
-			handleInitialize(writer, req.ID)
-		case "tools/list":
-			log.Printf("[%v] Listing available tools", req.ID)
-			handleToolsList(writer, req.ID)
-		case "tools/call":
-			var call ToolCallRequest
-			if err := json.Unmarshal(req.Params, &call); err != nil {
-				log.Printf("[%v] Failed to parse tool call: %v", req.ID, err)
-				sendResponse(writer, req.ID, nil, &JSONRPCError{
-					Code:    -32600,
-					Message: "Invalid arguments",
-				})
-			} else {
-				log.Printf("[%v] Calling tool: %s with args: %v", req.ID, call.Name, call.Arguments)
-				handleToolCall(writer, req.ID, call)
-				log.Printf("[%v] Tool call completed", req.ID)
-			}
-		default:
-			log.Printf("Unknown method: %s", req.Method)
-			sendResponse(writer, req.ID, nil, &JSONRPCError{
-				Code:    -32601,
-				Message: "Method not found",
-			})
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		log.Fatalf("Scanner error: %v", err)
+	if err := srv.Serve(context.Background(), os.Stdin, os.Stdout); err != nil {
+		log.Fatalf("serve: %v", err)
 	}
 }

--- a/cmd/livegrep-mcp-server/main_test.go
+++ b/cmd/livegrep-mcp-server/main_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	pb "github.com/livegrep/livegrep/src/proto/go_proto"
+	"google.golang.org/grpc"
+)
+
+// fakeClient is a test double for pb.CodeSearchClient. Each method delegates to
+// a function field so individual tests can control behavior.
+type fakeClient struct {
+	search func(*pb.Query) (*pb.CodeSearchResult, error)
+	info   func(*pb.InfoRequest) (*pb.ServerInfo, error)
+}
+
+func (f *fakeClient) Search(_ context.Context, q *pb.Query, _ ...grpc.CallOption) (*pb.CodeSearchResult, error) {
+	return f.search(q)
+}
+
+func (f *fakeClient) Info(_ context.Context, r *pb.InfoRequest, _ ...grpc.CallOption) (*pb.ServerInfo, error) {
+	return f.info(r)
+}
+
+func (f *fakeClient) Reload(_ context.Context, _ *pb.Empty, _ ...grpc.CallOption) (*pb.Empty, error) {
+	return &pb.Empty{}, nil
+}
+
+func newRequest(t *testing.T, id interface{}, method string, params interface{}) *Request {
+	t.Helper()
+	var raw json.RawMessage
+	if params != nil {
+		data, err := json.Marshal(params)
+		if err != nil {
+			t.Fatalf("marshal params: %v", err)
+		}
+		raw = data
+	}
+	return &Request{JSONRPC: "2.0", ID: id, Method: method, Params: raw}
+}
+
+func TestInitialize(t *testing.T) {
+	s := NewServer(&fakeClient{})
+	resp := s.handleRequest(context.Background(), newRequest(t, 1, "initialize", nil))
+	if resp == nil || resp.Error != nil {
+		t.Fatalf("unexpected error response: %+v", resp)
+	}
+	result := resp.Result.(map[string]interface{})
+	if result["protocolVersion"] != protocolVersion {
+		t.Errorf("protocolVersion = %v, want %v", result["protocolVersion"], protocolVersion)
+	}
+}
+
+func TestNotificationsGetNoResponse(t *testing.T) {
+	s := NewServer(&fakeClient{})
+	for _, method := range []string{"notifications/initialized", "notifications/cancelled"} {
+		req := &Request{JSONRPC: "2.0", Method: method} // no id => notification
+		if resp := s.handleRequest(context.Background(), req); resp != nil {
+			t.Errorf("%s: got response %+v, want nil", method, resp)
+		}
+	}
+}
+
+func TestToolsList(t *testing.T) {
+	s := NewServer(&fakeClient{})
+	resp := s.handleRequest(context.Background(), newRequest(t, 1, "tools/list", nil))
+	if resp == nil || resp.Error != nil {
+		t.Fatalf("unexpected error response: %+v", resp)
+	}
+	tools := resp.Result.(ToolsListResult).Tools
+	want := map[string]bool{"code_search": true, "search_files": true, "get_repos": true}
+	if len(tools) != len(want) {
+		t.Fatalf("got %d tools, want %d", len(tools), len(want))
+	}
+	for _, tool := range tools {
+		if !want[tool.Name] {
+			t.Errorf("unexpected tool %q", tool.Name)
+		}
+	}
+}
+
+func TestUnknownMethod(t *testing.T) {
+	s := NewServer(&fakeClient{})
+	resp := s.handleRequest(context.Background(), newRequest(t, 1, "does/not/exist", nil))
+	if resp == nil || resp.Error == nil {
+		t.Fatalf("expected error response, got %+v", resp)
+	}
+	if resp.Error.Code != errMethodNotFound {
+		t.Errorf("code = %d, want %d", resp.Error.Code, errMethodNotFound)
+	}
+}
+
+func callTool(t *testing.T, s *Server, name string, args map[string]interface{}) *ToolCallResult {
+	t.Helper()
+	resp := s.handleRequest(context.Background(), newRequest(t, 1, "tools/call", ToolCallRequest{
+		Name:      name,
+		Arguments: args,
+	}))
+	if resp == nil || resp.Error != nil {
+		t.Fatalf("unexpected error response: %+v", resp)
+	}
+	res, ok := resp.Result.(ToolCallResult)
+	if !ok {
+		t.Fatalf("result is %T, want ToolCallResult", resp.Result)
+	}
+	return &res
+}
+
+func TestCodeSearchSuccess(t *testing.T) {
+	var gotQuery *pb.Query
+	s := NewServer(&fakeClient{
+		search: func(q *pb.Query) (*pb.CodeSearchResult, error) {
+			gotQuery = q
+			return &pb.CodeSearchResult{
+				Stats: &pb.SearchStats{Re2Time: 5, AnalyzeTime: 3},
+				Results: []*pb.SearchResult{
+					{Tree: "repo1", Path: "a.go", LineNumber: 10, Line: "hello", Bounds: &pb.Bounds{Left: 0, Right: 5}},
+				},
+			}, nil
+		},
+	})
+
+	res := callTool(t, s, "code_search", map[string]interface{}{"query": "hello", "repo": "repo1"})
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", res.Content[0].Text)
+	}
+
+	// The query passed to the backend should carry our arguments and defaults.
+	if gotQuery.Line != "hello" || gotQuery.Repo != "repo1" {
+		t.Errorf("query = %+v, want Line=hello Repo=repo1", gotQuery)
+	}
+	if !gotQuery.FoldCase {
+		t.Error("FoldCase should be true when case_sensitive is unset")
+	}
+	if gotQuery.ContextLines != defaultContextLines {
+		t.Errorf("ContextLines = %d, want %d", gotQuery.ContextLines, defaultContextLines)
+	}
+
+	// The MCP envelope must contain one text content block with the JSON payload.
+	if len(res.Content) != 1 || res.Content[0].Type != "text" {
+		t.Fatalf("content = %+v, want single text block", res.Content)
+	}
+	var payload SearchResponse
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &payload); err != nil {
+		t.Fatalf("content is not valid JSON: %v", err)
+	}
+	if len(payload.Results) != 1 || payload.Results[0].Repo != "repo1" {
+		t.Errorf("results = %+v", payload.Results)
+	}
+}
+
+func TestCodeSearchMissingQuery(t *testing.T) {
+	s := NewServer(&fakeClient{})
+	res := callTool(t, s, "code_search", map[string]interface{}{})
+	if !res.IsError {
+		t.Fatal("expected isError result for missing query")
+	}
+	if !strings.Contains(res.Content[0].Text, "query parameter is required") {
+		t.Errorf("unexpected error text: %s", res.Content[0].Text)
+	}
+}
+
+func TestCodeSearchNilBounds(t *testing.T) {
+	s := NewServer(&fakeClient{
+		search: func(*pb.Query) (*pb.CodeSearchResult, error) {
+			return &pb.CodeSearchResult{
+				Stats:   &pb.SearchStats{},
+				Results: []*pb.SearchResult{{Tree: "r", Path: "p", Line: "x"}}, // Bounds nil
+			}, nil
+		},
+	})
+	res := callTool(t, s, "code_search", map[string]interface{}{"query": "x"})
+	if res.IsError {
+		t.Fatalf("nil bounds should not error: %s", res.Content[0].Text)
+	}
+}
+
+func TestSearchFiles(t *testing.T) {
+	var gotQuery *pb.Query
+	s := NewServer(&fakeClient{
+		search: func(q *pb.Query) (*pb.CodeSearchResult, error) {
+			gotQuery = q
+			return &pb.CodeSearchResult{
+				Stats:       &pb.SearchStats{},
+				FileResults: []*pb.FileResult{{Tree: "repo1", Path: "main.go"}},
+			}, nil
+		},
+	})
+	res := callTool(t, s, "search_files", map[string]interface{}{"pattern": "main"})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content[0].Text)
+	}
+	if !gotQuery.FilenameOnly {
+		t.Error("search_files should set FilenameOnly")
+	}
+	var payload FileSearchResponse
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &payload); err != nil {
+		t.Fatalf("invalid JSON payload: %v", err)
+	}
+	if len(payload.Results) != 1 || payload.Results[0].Path != "main.go" {
+		t.Errorf("results = %+v", payload.Results)
+	}
+}
+
+func TestGetRepos(t *testing.T) {
+	s := NewServer(&fakeClient{
+		info: func(*pb.InfoRequest) (*pb.ServerInfo, error) {
+			return &pb.ServerInfo{Trees: []*pb.ServerInfo_Tree{{Name: "a"}, {Name: "b"}}}, nil
+		},
+	})
+	res := callTool(t, s, "get_repos", nil)
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content[0].Text)
+	}
+	var payload RepoResponse
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &payload); err != nil {
+		t.Fatalf("invalid JSON payload: %v", err)
+	}
+	if len(payload.Repos) != 2 {
+		t.Errorf("got %d repos, want 2", len(payload.Repos))
+	}
+}
+
+func TestUnknownTool(t *testing.T) {
+	s := NewServer(&fakeClient{})
+	resp := s.handleRequest(context.Background(), newRequest(t, 1, "tools/call", ToolCallRequest{Name: "nope"}))
+	if resp == nil || resp.Error == nil {
+		t.Fatalf("expected error response, got %+v", resp)
+	}
+}
+
+func TestServeParseError(t *testing.T) {
+	s := NewServer(&fakeClient{})
+	var out strings.Builder
+	if err := s.Serve(context.Background(), strings.NewReader("{not json}\n"), &out); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+	var resp Response
+	if err := json.Unmarshal([]byte(out.String()), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if resp.Error == nil || resp.Error.Code != errParse {
+		t.Errorf("expected parse error, got %+v", resp.Error)
+	}
+}
+
+func TestServeNotificationProducesNoOutput(t *testing.T) {
+	s := NewServer(&fakeClient{})
+	var out strings.Builder
+	in := strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")
+	if err := s.Serve(context.Background(), in, &out); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+	if out.String() != "" {
+		t.Errorf("notification produced output: %q", out.String())
+	}
+}

--- a/cmd/livegrep/livegrep.go
+++ b/cmd/livegrep/livegrep.go
@@ -31,7 +31,17 @@ func runfilesPath(sourcePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(programPath+".runfiles", "com_github_livegrep_livegrep", sourcePath), nil
+	runfilesDir := programPath + ".runfiles"
+
+	// Try new runfiles layout first (_main)
+	newPath := path.Join(runfilesDir, "_main", sourcePath)
+	if _, err := os.Stat(newPath); err == nil {
+		return newPath, nil
+	}
+
+	// Fall back to old runfiles layout
+	oldPath := path.Join(runfilesDir, "com_github_livegrep_livegrep", sourcePath)
+	return oldPath, nil
 }
 
 func main() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,13 @@
 #   docker compose up                     # backend + web UI at http://localhost:8910
 #
 
+x-base: &base
+  image: ghcr.io/livegrep/livegrep/base:latest
+  platform: linux/amd64
+
 services:
   codesearch:
-    image: livegrep/base:latest
-    platform: linux/amd64
+    <<: *base
     working_dir: /repo
     # Index this repo using the bundled example config (indexes src/ and the
     # git HEAD of the repo) and serve gRPC on all interfaces.
@@ -27,8 +30,7 @@ services:
       - "${CODESEARCH_PORT:-9999}:9999"
 
   web:
-    image: livegrep/base:latest
-    platform: linux/amd64
+    <<: *base
     depends_on:
       - codesearch
     command: ["/livegrep/bin/livegrep", "-listen", "0.0.0.0:8910", "-connect", "codesearch:9999", "-docroot", "/livegrep/web"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+# Local livegrep stack for developing/validating livegrep-mcp-server.
+#
+# Provides the C++ `codesearch` backend (from the public livegrep/base image)
+# indexing this repo, plus the livegrep web UI. The mcp-server itself is a
+# stdio process spawned by an MCP client, so it is not a long-running service
+# here; run it on the host against the exposed backend on localhost:9999, e.g.:
+#
+#   bazel run //cmd/livegrep-mcp-server -- -backend localhost:9999
+#
+# Usage:
+#   docker compose up codesearch          # backend only (what the mcp-server needs)
+#   docker compose up                     # backend + web UI at http://localhost:8910
+#
+
+services:
+  codesearch:
+    image: livegrep/base:latest
+    platform: linux/amd64
+    working_dir: /repo
+    # Index this repo using the bundled example config (indexes src/ and the
+    # git HEAD of the repo) and serve gRPC on all interfaces.
+    command: ["/livegrep/bin/codesearch", "-grpc", "0.0.0.0:9999", "doc/examples/livegrep/index.json"]
+    volumes:
+      - .:/repo:ro
+    # Override the host port if 9999 is already in use: CODESEARCH_PORT=19999 docker compose up
+    ports:
+      - "${CODESEARCH_PORT:-9999}:9999"
+
+  web:
+    image: livegrep/base:latest
+    platform: linux/amd64
+    depends_on:
+      - codesearch
+    command: ["/livegrep/bin/livegrep", "-listen", "0.0.0.0:8910", "-connect", "codesearch:9999", "-docroot", "/livegrep/web"]
+    ports:
+      - "${WEB_PORT:-8910}:8910"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/livegrep/livegrep
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.25.5
 
 require (
 	github.com/bazelbuild/rules_go v0.55.1
@@ -25,6 +23,7 @@ require (
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.1.0 // indirect
+	github.com/mark3labs/mcp-go v0.1.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,12 +42,17 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mark3labs/mcp-go v0.1.0 h1:miH9EQawRIvP2tM8SoQYXxi0Nm+YTV+T/XCmhGaKKDw=
+github.com/mark3labs/mcp-go v0.1.0/go.mod h1:xWMnxgMARGtpclNygj0Tmp9fWST8JnN/ifZdhDiU9Ic=
+github.com/mark3labs/mcp-go v0.54.1 h1:Ap/ptEB9FtWzFKM8NDsTA7QDxerQOC06eZigrTldVj0=
+github.com/mark3labs/mcp-go v0.54.1/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
 github.com/nelhage/go.cli v0.0.0-20140717043504-2aeb96ef8025 h1:RPjitJVxtv+vBCezBG5cYcmycshpR1BjKKUX7CXSFgI=
 github.com/nelhage/go.cli v0.0.0-20140717043504-2aeb96ef8025/go.mod h1:VkLMyeyi5gqxk3F1KrVrHLYxTqUp//TBgm1GJ1scU8I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=


### PR DESCRIPTION
# Summary

This PR adds an MCP (Model Context Protocol) server that bridges AI assistants (Claude, etc...) to livegrep's code search backend. The server exposes three tools:
  - `code_search`: search code by regex pattern
  - `search_files`: find files by name/path
  - `get_repos`: list indexed repositories

## Quick start

```
docker compose up codesearch        # Start backend
bazel build //cmd/livegrep-mcp-server  # Build server
cp .mcp.json.example .mcp.json      # Configure (update path)
```
